### PR TITLE
Fix for issue #193

### DIFF
--- a/sumatra/commands.py
+++ b/sumatra/commands.py
@@ -229,7 +229,7 @@ def configure(argv):
     parser.add_argument('-t', '--timestamp_format', help="the timestamp format given to strftime")
     parser.add_argument('-L', '--launch_mode', choices=['serial', 'distributed', 'slurm-mpi'], help="how computations should be launched.")
     parser.add_argument('-o', '--launch_mode_options', help="extra options for the given launch mode, to be given in quotes with a leading space, e.g. ' --foo=3'")
-    parser.add_argument('-p', '--plain', action='store_true', help="pass arguments to the run command straight through to the program.")
+    parser.add_argument('-p', '--plain', action='store_true', help="pass arguments to the 'run' command straight through to the program. Otherwise arguments of the form name=value can be used to overwrite default parameter values.")
     parser.add_argument('-s', '--store', help="Change the record store to the specified path, URL or URI (must be specified). {0}".format(store_arg_help))
 
     datastore = parser.add_mutually_exclusive_group()

--- a/sumatra/commands.py
+++ b/sumatra/commands.py
@@ -229,7 +229,8 @@ def configure(argv):
     parser.add_argument('-t', '--timestamp_format', help="the timestamp format given to strftime")
     parser.add_argument('-L', '--launch_mode', choices=['serial', 'distributed', 'slurm-mpi'], help="how computations should be launched.")
     parser.add_argument('-o', '--launch_mode_options', help="extra options for the given launch mode, to be given in quotes with a leading space, e.g. ' --foo=3'")
-    parser.add_argument('-p', '--plain', action='store_true', help="pass arguments to the 'run' command straight through to the program. Otherwise arguments of the form name=value can be used to overwrite default parameter values.")
+    parser.add_argument('-p', '--plain', dest='plain', action='store_true', help="pass arguments to the 'run' command straight through to the program. Otherwise arguments of the form name=value can be used to overwrite default parameter values.")
+    parser.add_argument('--no-plain', dest='plain', action='store_false', help="arguments to the 'run' command of the form name=value will overwrite default parameter values. This is the opposite of the --plain option.")
     parser.add_argument('-s', '--store', help="Change the record store to the specified path, URL or URI (must be specified). {0}".format(store_arg_help))
 
     datastore = parser.add_mutually_exclusive_group()
@@ -287,8 +288,8 @@ def configure(argv):
         project.default_launch_mode = get_launch_mode(args.launch_mode)()
     if args.launch_mode_options:
         project.default_launch_mode.options = args.launch_mode_options.strip()
-    if args.plain:
-        project.allow_command_line_parameters = False
+    if args.plain is not None:
+        project.allow_command_line_parameters = not args.plain
     project.save()
 
 

--- a/sumatra/projects.py
+++ b/sumatra/projects.py
@@ -34,6 +34,7 @@ import django
 import sqlite3
 import time
 import shutil
+import textwrap
 from datetime import datetime
 from sumatra.records import Record
 from sumatra import programs, datastore
@@ -122,7 +123,23 @@ class Project(object):
                      'data_label', '_most_recent', 'input_datastore',
                      'label_generator', 'timestamp_format', 'sumatra_version',
                      'allow_command_line_parameters'):
-            attr = getattr(self, name, None)
+            try:
+                attr = getattr(self, name)
+            except:
+                # Some parameters which need special treatment to avoid
+                # unexpected behaviour.
+                if name == 'allow_command_line_parameters':
+                    print(textwrap.dedent("""\
+                        Upgrading from a Sumatra version which did not have the --plain configuration
+                        option. After this upgrade, arguments to 'smt run' of the form 'name=value'
+                        will continue to overwrite default parameter values, but this is now
+                        configurable. If it is desired that they should be passed straight through
+                        to the program, run the command 'smt configure --plain' after this upgrade.
+                        """))
+                    attr = True
+                else:
+                    # Default value for unrecognised parameters
+                    attr = None
             if hasattr(attr, "__getstate__"):
                 state[name] = {'type': attr.__class__.__module__ + "." + attr.__class__.__name__}
                 for key, value in attr.__getstate__().items():


### PR DESCRIPTION
The cause for issue #193 was that when a project was upgraded, Sumatra would internally call `project.save()`, which sets any unrecognised configuration parameters to `None`. This would in particular set `allow_command_line_parameters=null` in `.smt/project`, and upon subsequent Sumatra runs this would be interpreted as `allow_command_line_parameters=false` so that any command line parameters would be ignored (whereas previously they would overwrite the default parameter values).

Now, when we're upgrading from a Sumatra version that didn't have this parameter we're setting it to `True` and print a message explaining to the user that this parameter has been silently set and how to change it.

I also introduced a `--no-plain` option to have a convenient way of reversing the effect of `--plain`.

As a side note, I haven't added a test for this issue because reproducing it requires installing an old Sumatra version (and in particular an older version of django). However, it might be sensible to introduce these kinds of tests so that any issues with upgrading projects can be detected. (This might require some sort of virtualenv in the testing framework.)