### PR TITLE
Fix for non-trivial library/require calls (fix #219)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: required
 python:
   - "2.7"
   - "2.6"

--- a/test/example_projects/R/myscript.R
+++ b/test/example_projects/R/myscript.R
@@ -1,4 +1,4 @@
-library(foreign)
+library(quietly=TRUE, package=foreign)
 library(MASS)
 
 args <- commandArgs(TRUE)


### PR DESCRIPTION
R script to parse dependencies now uses `getParseData` which should be much more robust.

Test updated to ensure this works with a convoluted library call.