### PR TITLE
Last stable 1.6 is OK

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
                    'Programming Language :: Python :: 2.7',
                    'Topic :: Scientific/Engineering'],
     cmdclass = {'sdist': sdist_hg},
-    install_requires = ['Django>=1.4, <=1.6', 'django-tagging', 'httplib2',
+    install_requires = ['Django>=1.4, <=1.6.11', 'django-tagging', 'httplib2',
                         'docutils', 'jinja2', 'parameters'],
     extras_require = {'svn': 'pysvn',
                       'hg': 'mercurial',


### PR DESCRIPTION
Note that fix done in #227 based on issue #226 forces reinstall with latest stable django on 1.6, i.e. 1.6.11. This PR fixes that.