### PR TITLE
Fix/yaml configparser command line

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
                    'Programming Language :: Python :: 2.7',
                    'Topic :: Scientific/Engineering'],
     cmdclass = {'sdist': sdist_hg},
-    install_requires = ['Django>=1.4, <=1.6', 'django-tagging', 'httplib2',
+    install_requires = ['Django>=1.4, <=1.6.11', 'django-tagging', 'httplib2',
                         'docutils', 'jinja2', 'parameters'],
     extras_require = {'svn': 'pysvn',
                       'hg': 'mercurial',

--- a/sumatra/commands.py
+++ b/sumatra/commands.py
@@ -102,7 +102,8 @@ def parse_arguments(args, input_datastore, stdin=None, stdout=None,
                 try:
                     ps.update(ps.parse_command_line_parameter(cl))
                 except ValueError as v:
-                    name, value = v.args
+                    message, name, value = v.args
+                    warnings.warn(message)
                     warnings.warn("'{0}={1}' not defined in the parameter file".format(name, value))
                     ps.update({name: value}) ## for now, add the command line param anyway
         else:

--- a/sumatra/parameters.py
+++ b/sumatra/parameters.py
@@ -54,13 +54,13 @@ class ParameterSet(object):
     required_attributes = ("update", "save")
     list_pattern = re.compile(r'^\s*\[.*\]\s*$')
     tuple_pattern = re.compile(r'^\s*\(.*\)\s*$')
-    casts = (int, float)
+    casts = (yaml.load, ) ## good behavior for all bool, at cost of dependency
 
     def _new_param_check(self, name, value):
         try:
             self.values[name]
-        except:
-            raise ValueError
+        except KeyError:
+            raise ValueError("")
 
 
     def parse_command_line_parameter(self, p):
@@ -88,8 +88,8 @@ class ParameterSet(object):
                     pass
         try:
             self._new_param_check(name, value)
-        except ValueError:
-            raise ValueError(name,  value)
+        except ValueError as v:
+            raise ValueError(v.message, name,  value)
             ## attempt to pass undefined param -- let commands.py deal with
 
         return {name: value}
@@ -101,6 +101,7 @@ class YAMLParameterSet(ParameterSet):
     PyYAML module
     """
     name = ".yaml"
+    casts = (yaml.load, )
 
     def __init__(self, initialiser):
         """
@@ -306,6 +307,7 @@ class ConfigParserParameterSet(SafeConfigParser, ParameterSet):
     parameter values are treated as strings.
     """
     name = ".cfg"
+    casts = (str, )
 
     def __init__(self, initialiser):
         """
@@ -413,6 +415,8 @@ class ConfigParserParameterSet(SafeConfigParser, ParameterSet):
             value = d
         return value
 
+    def _new_param_check(self, name, value):
+        raise ValueError("Config file: parameter name checking not implemented!")
 
 class JSONParameterSet(ParameterSet):
     """

--- a/sumatra/parameters.py
+++ b/sumatra/parameters.py
@@ -101,7 +101,6 @@ class YAMLParameterSet(ParameterSet):
     PyYAML module
     """
     name = ".yaml"
-    casts = (yaml.load, )
 
     def __init__(self, initialiser):
         """
@@ -180,6 +179,7 @@ class SimpleParameterSet(ParameterSet):
     Handles parameter files in a simple "name = value" format, with no nesting or grouping.
     """
     name = ".simpleparameterset"
+    casts = (int, float)
 
     def __init__(self, initialiser):
         """

--- a/test/unittests/test_commands.py
+++ b/test/unittests/test_commands.py
@@ -772,9 +772,10 @@ class ArgumentParsingTests(unittest.TestCase):
                       YAMLParameterSet(""))
         self.PConfigParser = ConfigParserParameterSet("")
         for k in ('a', 'b', 'c', 'd', 'l', 'save'):
-            self.PConfigParser.update({k: 1})
+            up_dict = {k: 1}
+            self.PConfigParser.update(up_dict)
             for P in self.PSETS:
-                P.update({k: 1})
+                P.update(up_dict)
 
     def test_parse_command_line_parameter_arg_must_contain_equals(self):
         for P in self.PSETS:
@@ -824,18 +825,19 @@ class ArgumentParsingTests(unittest.TestCase):
         PS, PJSON, PYAML = self.PSETS
         result = PJSON.parse_command_line_parameter("l=false")
         self.assertEqual(result, {'l': False})
-        for P in (PS, PYAML):
-            # yaml has language agnostic bool
-            result = P.parse_command_line_parameter("l=False") #python-like
-            self.assertEqual(result, {'l': False})
-            result = P.parse_command_line_parameter("l=false") #json-like
-            self.assertEqual(result, {'l': False})
-            result = P.parse_command_line_parameter("l=FALSE") #r-like
-            self.assertEqual(result, {'l': False})
-            result = P.parse_command_line_parameter("l=off") # possibly undesired
-            self.assertEqual(result, {'l': False})
-            result = P.parse_command_line_parameter("l=On") # possibly undesired
-            self.assertEqual(result, {'l': True})
+        result = PS.parse_command_line_parameter("l=false")
+        self.assertEqual(result, {'l': 'false'})
+        # yaml has language agnostic bool
+        result = PYAML.parse_command_line_parameter("l=False") #python-like
+        self.assertEqual(result, {'l': False})
+        result = PYAML.parse_command_line_parameter("l=false") #json-like
+        self.assertEqual(result, {'l': False})
+        result = PYAML.parse_command_line_parameter("l=FALSE") #r-like
+        self.assertEqual(result, {'l': False})
+        result = PYAML.parse_command_line_parameter("l=off") # possibly undesired
+        self.assertEqual(result, {'l': False})
+        result = PYAML.parse_command_line_parameter("l=On") # possibly undesired
+        self.assertEqual(result, {'l': True})
 
     def test_parse_command_line_parameter_with_tuple(self):
         for P in self.PSETS:


### PR DESCRIPTION
This adds YAML and changes the default parser to YAML -- which has language agnostic boolean parsing so will change R `FALSE`, Python `False` and json `false` all to Python `False`. 

It also casts all args for ConfigParser to string, but only has a stub for checking if params are in ConfigParser file -- currently it will warn for every parameter passed on command line but this could be changed on line 418 of `sumatra/parameters.py`