### PR TITLE
Enhancement/bash complete

### DIFF
--- a/bin/smt-complete.sh
+++ b/bin/smt-complete.sh
@@ -1,0 +1,46 @@
+# edited manually after using 'magic' autocomplete provided
+# via click: http://click.pocoo.org/4/bashcomplete/
+#(smt)~/smt (enhancement/bash-complete)$ _SMT_COMPLETE=source smt
+## which produces
+#_smt_completion() {
+#    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
+#                   COMP_CWORD=$COMP_CWORD \
+#                   _SMT_COMPLETE=complete $1 ) )
+#    return 0
+#}
+#
+#complete -F _smt_completion -o default smt;
+
+_smt_completion() {
+
+    local crp1 crp2
+
+    crp1=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
+                   COMP_CWORD=$COMP_CWORD \
+                   _SMT_COMPLETE=complete $1 ) )
+
+    # note this requires labels stored in .smt/labels of CWD
+    local cur prev1 want_labels labels
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev1="${COMP_WORDS[COMP_CWORD-1]}"
+    labels=$(cat .smt/labels)
+    case "${prev1}" in
+	comment|delete|diff|migrate|repeat|run|tag)
+	    crp2=( $(compgen -W "${labels}" -- ${cur}) )
+	    COMPREPLY=("${crp1[@]}" "${crp2[@]}")
+	    return 0
+	    ;;
+	*)
+	    if [[ ${labels} == *${prev1}* ]]
+	    then
+		    crp2=( $(compgen -W "${labels}" -- ${cur}) )
+		    COMPREPLY=("${crp1[@]}" "${crp2[@]}")
+		    return 0
+	    fi
+	    COMPREPLY=("${crp1[@]}")
+	    return 0
+	    ;;
+    esac
+}
+
+complete -F _smt_completion -o default smt;

--- a/doc/installation.txt
+++ b/doc/installation.txt
@@ -68,3 +68,14 @@ GitPython_ package.
 .. _`Python(x,y)`: http://code.google.com/p/pythonxy/
 .. _Anaconda: http://docs.continuum.io/anaconda/
 .. _docutils: http://docutils.sourceforge.net
+
+Command completion for bash
+--------------------------
+
+Sumatra comes with a limited bash completion facility.
+You can install it to you system by sourcing the file
+`smt-completion.sh` in your `.bashrc` or `.profile.
+By default, Sumatra installs this script to your
+`/usr/bin` directory by default but moving it
+elsewhere (e.g. to `~/.bash_completion.d/`)
+is recommended.

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
                                 'web/templates/*.html',
                                 'publishing/latex/sumatra.sty',
                                 'formatting/latex_template.tex', 'external_scripts/script_introspect.R']},
-    scripts = ['bin/smt', 'bin/smtweb'],
+    scripts = ['bin/smt', 'bin/smtweb', 'bin/smt-complete.sh'],
     author = "Sumatra authors and contributors",
     author_email = "andrew.davison@unic.cnrs-gif.fr",
     description = "A tool for automated tracking of computation-based scientific projects",

--- a/sumatra/commands.py
+++ b/sumatra/commands.py
@@ -203,6 +203,10 @@ def init(argv):
                       input_datastore=input_datastore,
                       label_generator=args.labelgenerator,
                       timestamp_format=args.timestamp_format)
+    if os.path.exists('.smt'):
+        f = open('.smt/labels', 'w')
+        f.writelines(project.format_records(tags=None, mode='short', format='text', reverse=False))
+        f.close()
     project.save()
 
 
@@ -404,8 +408,11 @@ def list(argv):  # add 'report' and 'log' as aliases
     args = parser.parse_args(argv)
 
     project = load_project()
+    if os.path.exists('.smt'):
+	f = open('.smt/labels', 'w')
+	f.writelines(project.format_records(tags=None, mode='short', format='text', reverse=False))
+	f.close()
     print(project.format_records(tags=args.tags, mode=args.mode, format=args.format, reverse=args.reverse))
-
 
 def delete(argv):
     """Delete records or records with a particular tag from a project."""


### PR DESCRIPTION
Implements a crude and limited version of bash completion as suggested in #224 that DOES autocomplete labels. It only knows about labels as of the last invocation of `smt list`. 

But, it is

* Limited because it doesn't know about subcommand arguments.
* Crude due to incompatibility between the bash subcommand completion script (which is modified from a a script provided as an output of the CLI tool development package click) and the way the helpfile for smt is currently written. Of course, this can be improved, but my bash skills are limited.