### PR TITLE
Added a "creation" attribute to `DataKey` and `DataItem`

### DIFF
--- a/sumatra/commands.py
+++ b/sumatra/commands.py
@@ -582,7 +582,10 @@ def upgrade(argv):
     args = parser.parse_args(argv)
 
     project = load_project()
-    if hasattr(project, 'sumatra_version') and project.sumatra_version == sumatra.__version__:
+    if (hasattr(project, 'sumatra_version')
+        and project.sumatra_version == sumatra.__version__
+        and "dev" not in sumatra.__version__):
+        
         print("No upgrade needed (project was created with an up-to-date version of Sumatra).")
         sys.exit(1)
 

--- a/sumatra/datastore/archivingfs.py
+++ b/sumatra/datastore/archivingfs.py
@@ -3,7 +3,7 @@ Datastore based on files written to the local filesystem, archived in gzipped
 tar files, then retrieved from the tar files.
 
 
-:copyright: Copyright 2006-2014 by the Sumatra team, see doc/authors.txt
+:copyright: Copyright 2006-2015 by the Sumatra team, see doc/authors.txt
 :license: CeCILL, see LICENSE for details.
 """
 
@@ -13,6 +13,7 @@ import tarfile
 import shutil
 import logging
 import mimetypes
+import datetime
 from contextlib import closing  # needed for Python 2.6
 from sumatra.core import TIMESTAMP_FORMAT, registry
 
@@ -25,11 +26,13 @@ class ArchivedDataFile(DataItem):
     """A file-like object, that represents a file inside a tar archive"""
     # current implementation just for real files
 
-    def __init__(self, path, store):
+    def __init__(self, path, store, creation=None):
         self.path = path
         archive_label = self.path.split(os.path.sep)[0]
         self.tarfile_path = os.path.join(store.archive_store, archive_label + ".tar.gz")
-        self.size = self._get_info().size
+        info = self._get_info()
+        self.size = info.size
+        self.creation = creation or datetime.datetime.fromtimestamp(info.mtime).replace(microsecond=0)
         self.name = os.path.basename(self.path)
         self.extension = os.path.splitext(self.name)
         self.mimetype, self.encoding = mimetypes.guess_type(self.path)

--- a/sumatra/datastore/base.py
+++ b/sumatra/datastore/base.py
@@ -1,7 +1,7 @@
 """
 
 
-:copyright: Copyright 2006-2014 by the Sumatra team, see doc/authors.txt
+:copyright: Copyright 2006-2015 by the Sumatra team, see doc/authors.txt
 :license: CeCILL, see LICENSE for details.
 """
 
@@ -75,16 +75,19 @@ class DataKey(object):
     available.
     """
 
-    def __init__(self, path, digest, **metadata):
+    def __init__(self, path, digest, creation, **metadata):
         self.path = path
         self.digest = digest
+        self.creation = creation
         self.metadata = metadata
 
     def __repr__(self):
-        return "%s(%s)" % (self.path, self.digest)
+        return "%s(%s [%s])" % (self.path, self.digest, self.creation)
 
     def __eq__(self, other):
-        return self.path == other.path and (self.digest == other.digest or IGNORE_DIGEST in (self.digest, other.digest))
+        return (self.path == other.path and
+                (self.digest == other.digest or IGNORE_DIGEST in (self.digest, other.digest)) and
+                self.creation == other.creation)
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -114,7 +117,7 @@ class DataItem(object):
 
     def generate_key(self):
         """Generate a :class:`DataKey` uniquely identifying this data item."""
-        return DataKey(self.path, self.digest, mimetype=self.mimetype,
+        return DataKey(self.path, self.digest, self.creation, mimetype=self.mimetype,
                        encoding=self.encoding, size=self.size)
 
     def get_content(self, max_length=None):

--- a/sumatra/datastore/filesystem.py
+++ b/sumatra/datastore/filesystem.py
@@ -2,7 +2,7 @@
 Datastore based on files written to and retrieved from a local filesystem.
 
 
-:copyright: Copyright 2006-2014 by the Sumatra team, see doc/authors.txt
+:copyright: Copyright 2006-2015 by the Sumatra team, see doc/authors.txt
 :license: CeCILL, see LICENSE for details.
 """
 
@@ -21,7 +21,7 @@ class DataFile(DataItem):
     """A file-like object, that represents a file in a local filesystem."""
     # current implementation just for real files
 
-    def __init__(self, path, store):
+    def __init__(self, path, store, creation=None):
         self.path = path
         self.full_path = os.path.join(store.root, path)
         if os.path.exists(self.full_path):
@@ -30,6 +30,7 @@ class DataFile(DataItem):
         else:
             raise IOError("File %s does not exist" % self.full_path)
             #self.size = None
+        self.creation = creation or datetime.datetime.fromtimestamp(stats.st_ctime).replace(microsecond=0)
         self.name = os.path.basename(self.full_path)
         self.extension = os.path.splitext(self.full_path)
         self.mimetype, self.encoding = mimetypes.guess_type(self.full_path)
@@ -128,7 +129,7 @@ class FileSystemDataStore(DataStore):
         Return the file that matches the given key.
         """
         try:
-            df = self.data_item_class(key.path, self)
+            df = self.data_item_class(key.path, self, key.creation)
         except IOError:
             raise KeyError("File %s does not exist." % key.path)
         if key.digest != IGNORE_DIGEST and df.digest != key.digest:

--- a/sumatra/datastore/mirroredfs.py
+++ b/sumatra/datastore/mirroredfs.py
@@ -6,13 +6,14 @@ The datastore itself does not take care of the mirroring, it is up to the
 user to take care of this.
 
 
-:copyright: Copyright 2006-2014 by the Sumatra team, see doc/authors.txt
+:copyright: Copyright 2006-2015 by the Sumatra team, see doc/authors.txt
 :license: CeCILL, see LICENSE for details.
 """
 
 import logging
 import os
 import mimetypes
+import datetime
 from ..compatibility import urlopen
 from ..core import registry
 from .base import DataItem, DataKey
@@ -25,14 +26,16 @@ class MirroredDataFile(DataItem):
     file system and on a webserver.
     """
 
-    def __init__(self, path, store):
+    def __init__(self, path, store, creation=None):
         self.path = path
         self.full_path = os.path.join(store.root, path)
         if os.path.exists(self.full_path):
             stats = os.stat(self.full_path)
             self.size = stats.st_size
+            self.creation = creation or datetime.datetime.fromtimestamp(stats.st_ctime).replace(microsecond=0)
         else:
             self.size = -1
+            self.creation = creation
         self.name = os.path.basename(self.full_path)
         self.extension = os.path.splitext(self.full_path)
         self.mimetype, self.encoding = mimetypes.guess_type(self.full_path)

--- a/sumatra/formatting/__init__.py
+++ b/sumatra/formatting/__init__.py
@@ -65,6 +65,7 @@ def record2json(record, indent=None):
             "path": key.path,
             "digest": key.digest,
             "metadata": key.metadata,
+            "creation": None if key.creation is None else key.creation.strftime("%Y-%m-%d %H:%M:%S")  # added in 0.7
         } for key in record.input_data],
         "script_arguments": record.script_arguments,  # added in 0.3
         "launch_mode": {
@@ -85,6 +86,7 @@ def record2json(record, indent=None):
             "path": key.path,
             "digest": key.digest,
             "metadata": key.metadata,
+            "creation": None if key.creation is None else key.creation.strftime("%Y-%m-%d %H:%M:%S")  # added in 0.7
         } for key in record.output_data],
         "tags": list(record.tags),  # not sure if tags should be PUT, perhaps have separate URL for this?
         "diff": record.diff,

--- a/sumatra/recordstore/django_store/models.py
+++ b/sumatra/recordstore/django_store/models.py
@@ -183,6 +183,7 @@ class Datastore(BaseModel):
 class DataKey(BaseModel):
     path = models.CharField(max_length=200)
     digest = models.CharField(max_length=40)
+    creation = models.DateTimeField(null=True, blank=True)
     metadata = models.TextField(blank=True)
 
     output_from_record = models.ForeignKey('Record', related_name =
@@ -196,7 +197,7 @@ class DataKey(BaseModel):
 
     def to_sumatra(self):
         metadata = eval(self.metadata)
-        return datastore.DataKey(self.path, self.digest, **metadata)
+        return datastore.DataKey(self.path, self.digest, self.creation, **metadata)
 
 
 class PlatformInformation(BaseModel):

--- a/sumatra/recordstore/serialization.py
+++ b/sumatra/recordstore/serialization.py
@@ -53,6 +53,8 @@ def decode_project_data(content):
 
 def datestring_to_datetime(s):
     """docstring"""
+    if s is None:
+        return s
     try:
         timestamp = datetime.strptime(s, "%Y-%m-%d %H:%M:%S")
     except ValueError:
@@ -103,10 +105,12 @@ def build_record(data):
         input_data = eval(input_data)
     if input_data:
         if isinstance(input_data[0], string_type):  # versions prior to 0.4
-            input_data = [datastore.DataKey(path, digest=datastore.IGNORE_DIGEST)
+            input_data = [datastore.DataKey(path, digest=datastore.IGNORE_DIGEST, creation=None)
                           for path in input_data]
         else:
-            input_data = [datastore.DataKey(keydata["path"], keydata["digest"], **keys2str(keydata["metadata"]))
+            input_data = [datastore.DataKey(keydata["path"], keydata["digest"],
+                                            creation=datestring_to_datetime(keydata.get("creation", None)),
+                                            **keys2str(keydata["metadata"]))
                           for keydata in input_data]
     record = Record(executable, repository, data["main_file"],
                     data["version"], launch_mode, data_store, parameter_set,
@@ -121,11 +125,14 @@ def build_record(data):
     record.output_data = []
     if "output_data" in data:
         for keydata in data["output_data"]:
-            data_key = datastore.DataKey(keydata["path"], keydata["digest"], **keys2str(keydata["metadata"]))
+            data_key = datastore.DataKey(keydata["path"], keydata["digest"],
+                                         creation=datestring_to_datetime(keydata.get("creation", None)),
+                                         **keys2str(keydata["metadata"]))
             record.output_data.append(data_key)
     elif "data_key" in data:  # (versions prior to 0.4)
         for path in eval(data["data_key"]):
-            data_key = datastore.DataKey(path, digest=datastore.IGNORE_DIGEST)
+            data_key = datastore.DataKey(path, digest=datastore.IGNORE_DIGEST,
+                                         creation=None)
             record.output_data.append(data_key)
     record.duration = data["duration"]
     record.outcome = data["outcome"]

--- a/sumatra/web/views.py
+++ b/sumatra/web/views.py
@@ -297,7 +297,7 @@ def download_file(request, project, label):
     label = unescape(label)
     path = request.GET['path']
     digest = request.GET['digest']
-    data_key = DataKey(path, digest)
+    data_key = DataKey(path, digest, request.GET.get('creation', None))
     record = Record.objects.get(label=label, project__id=project)
     data_store = get_data_store(record.datastore.type, eval(record.datastore.parameters))
 

--- a/test/unittests/example_0.7.json
+++ b/test/unittests/example_0.7.json
@@ -1,0 +1,94 @@
+{
+    "script_arguments": "arg1 arg2 arg3",
+    "platforms": [
+        {
+            "system_name": "Linux",
+            "ip_addr": "127.0.1.1",
+            "architecture_bits": "64bit",
+            "machine": "x86_64",
+            "architecture_linkage": "ELF",
+            "version": "#50-Ubuntu SMP Mon Sep 12 21:17:25 UTC 2011",
+            "release": "2.6.38-11-generic",
+            "network_name": "my_pc",
+            "processor": "x86_64"
+        }
+    ],
+    "duration": 2.196953773498535,
+    "diff": "",
+    "datastore": {
+        "type": "ArchivingFileSystemDataStore",
+        "parameters": {
+            "root": "/path/to/root",
+            "archive": "/path/to/archive"
+        }
+    },
+    "input_datastore": {
+        "type": "FileSystemDataStore",
+        "parameters": {
+            "root": "/"
+        }
+    },
+    "executable": {
+        "path": "/path/to/bin/python",
+        "version": "2.7.1",
+        "name": "Python",
+        "options": ""
+    },
+    "parameters": {
+        "content": "{}",
+        "type": "dict"
+    },
+    "label": "haggling",
+    "version": "5f6221aa3a14",
+    "stdout_stderr": "No output.",
+    "repository": {
+        "url": "https://hg.example.com/MyProject",
+        "type": "MercurialRepository",
+        "upstream": null
+    },
+    "tags": ["foo", "bar"],
+    "timestamp": "2012-09-28 11:40:20",
+    "reason": "Determine the answer to the ultimate question of life, the universe and everything",
+    "dependencies": [
+        {
+            "name": "matplotlib",
+            "module": "python",
+            "source": null,
+            "version": "1.0.1",
+            "diff": "",
+            "path": "/path/to/matplotlib"
+        },
+        {
+            "name": "numpy",
+            "module": "python",
+            "source": null,
+            "version": "1.5.1",
+            "diff": "",
+            "path": "/path/to/numpy"
+        }
+    ],
+    "user": "",
+    "output_data": [
+        {
+            "path": "haggling/output.png",
+            "digest": "a49f2032684d66e9790474d027a3f673a55180f5",
+            "creation": "2012-09-28 11:40:21",
+            "metadata": {
+                "mimetype": "image/png",
+                "encoding": null,
+                "size": 103579
+            }
+        }
+    ],
+    "input_data": [],
+    "launch_mode": {
+        "type": "SerialLaunchMode",
+        "parameters": {
+            "working_directory": "/current/working/directory",
+            "options": null
+        }
+    },
+    "main_file": "plot.py",
+    "outcome": "42",
+    "repeats": null
+}

--- a/test/unittests/test_commands.py
+++ b/test/unittests/test_commands.py
@@ -8,6 +8,7 @@ except ImportError:
     import unittest
 import os
 import hashlib
+from datetime import datetime
 from sumatra import commands, launch, datastore
 from sumatra.parameters import (SimpleParameterSet, JSONParameterSet,
                                 YAMLParameterSet, ConfigParserParameterSet)
@@ -15,11 +16,13 @@ from sumatra.parameters import (SimpleParameterSet, JSONParameterSet,
 originals = []  # use for storing originals of mocked objects
 
 
+back_to_the_future = datetime(2015, 10, 21, 16, 29, 0)
+
 class MockDataStore(object):
     def __init__(self, root):
         self.root = root
     def generate_keys(self, *paths):
-        return [datastore.DataKey(path, datastore.IGNORE_DIGEST) for path in paths]
+        return [datastore.DataKey(path, datastore.IGNORE_DIGEST, back_to_the_future) for path in paths]
     def contains_path(self, path):
         return os.path.isfile(path)
 
@@ -523,7 +526,7 @@ class RunCommandTests(unittest.TestCase):
                          'parameters': {},
                          'main_file': 'default',
                          'label': None,
-                         'input_data': [datastore.DataKey('this.is.not.a.parameter.file', hashlib.sha1(data_content).hexdigest())],
+                         'input_data': [datastore.DataKey('this.is.not.a.parameter.file', hashlib.sha1(data_content).hexdigest(), back_to_the_future)],
                          'reason': '',
                          'version': 'current',
                          'script_args': 'this.is.not.a.parameter.file'})
@@ -547,7 +550,8 @@ class RunCommandTests(unittest.TestCase):
                          'main_file': 'main.py',
                          'label': 'vikings',
                          'input_data': [datastore.DataKey('this.is.not.a.parameter.file',
-                                                          hashlib.sha1(data_content).hexdigest())],
+                                                          hashlib.sha1(data_content).hexdigest(),
+                                                          back_to_the_future)],
                          'reason': 'test',
                          'version': '234',
                          'script_args': "spam <parameters> eggs this.is.not.a.parameter.file beans"})

--- a/test/unittests/test_datastore.py
+++ b/test/unittests/test_datastore.py
@@ -54,20 +54,20 @@ class TestFileSystemDataStore(unittest.TestCase):
 
     def test__get_content__should_return_short_file_content(self):
         digest = hashlib.sha1(self.test_data).hexdigest()
-        key = DataKey('test_file1', digest)
+        key = DataKey('test_file1', digest, creation=None)
         content = self.ds.get_content(key)
         self.assertEqual(content, self.test_data)
 
     def test__get_content__should_truncate_long_files(self):
         digest = hashlib.sha1(self.test_data).hexdigest()
-        key = DataKey('test_file1', digest)
+        key = DataKey('test_file1', digest, creation=self.now)
         content = self.ds.get_content(key, max_length=10)
         self.assertEqual(content, self.test_data[:10])
 
     def test__delete__should_remove_files(self):
         assert os.path.exists(os.path.join(self.root_dir, 'test_file1'))
         digest = hashlib.sha1(self.test_data).hexdigest()
-        keys = [DataKey(path, digest) for path in self.test_files]
+        keys = [DataKey(path, digest, creation=None) for path in self.test_files]
         self.ds.delete(*keys)
         self.assert_(not os.path.exists(os.path.join(self.root_dir, 'test_file1')))
 
@@ -130,14 +130,17 @@ class TestArchivingFileSystemDataStore(unittest.TestCase):
     def test__get_content__should_return_short_file_content(self):
         self.ds.find_new_data(self.now)
         digest = hashlib.sha1(self.test_data).hexdigest()
-        key = DataKey('%s/test_file1' % self.now.strftime(TIMESTAMP_FORMAT), digest)
+        key = DataKey('%s/test_file1' % self.now.strftime(TIMESTAMP_FORMAT),
+                      digest, creation=self.now)
         content = self.ds.get_content(key)
         self.assertEqual(content, self.test_data)
 
     def test__get_content__should_truncate_long_files(self):
         self.ds.find_new_data(self.now)
         digest = hashlib.sha1(self.test_data).hexdigest()
-        key = DataKey('%s/test_file1' % self.now.strftime(TIMESTAMP_FORMAT), digest)
+        now = self.now.strftime(TIMESTAMP_FORMAT)
+        key = DataKey('%s/test_file1' % self.now.strftime(TIMESTAMP_FORMAT),
+                      digest, creation=self.now)
         content = self.ds.get_content(key, max_length=10)
         self.assertEqual(content, self.test_data[:10])
 

--- a/test/unittests/test_publishing.py
+++ b/test/unittests/test_publishing.py
@@ -11,6 +11,7 @@ import sys
 import os
 import shutil
 from textwrap import dedent
+from datetime import datetime
 try:
     from docutils.core import publish_string
     have_docutils = True
@@ -55,8 +56,8 @@ class MockRecord(object):
     
     def __init__(self, label):
         self.label = label
-        key = DataKey("bar.jpg", "0123456789abcdef")
-        other_key = DataKey("subdirectory/baz.png", "fedcba9876543210")
+        key = DataKey("bar.jpg", "0123456789abcdef", datetime(2015, 10, 21, 16, 29, 0))
+        other_key = DataKey("subdirectory/baz.png", "fedcba9876543210", datetime(2015, 10, 21, 16, 31, 23))
         #key.url = "http://example.com/my_data/bar.jpg"
         self.output_data = [key, other_key]
         self.datastore = MockDataStore()

--- a/test/unittests/test_recordstore.py
+++ b/test/unittests/test_recordstore.py
@@ -485,8 +485,13 @@ class TestSerialization(unittest.TestCase):
             record = serialization.build_record(json.load(fp))
         self.assertEqual(record.label, "haggling")    
 
+    def test_build_record_v0p6(self):
+        with open(os.path.join(this_directory, "example_0.6.json")) as fp:
+            record = serialization.build_record(json.load(fp))
+        self.assertEqual(record.label, "haggling")
+
     def test_round_trip(self):
-        with open(os.path.join(this_directory,"example_0.6.json")) as fp:
+        with open(os.path.join(this_directory, "example_0.7.json")) as fp:
             data_in = json.load(fp)
         record = serialization.build_record(data_in)
         data_out = json.loads(serialization.encode_record(record, indent=2))


### PR DESCRIPTION
since "path" and "digest" do not uniquely identify an object.

This completes the work done by @Felix11H on providing a data-centric view in Sumatra (see https://bitbucket.org/apdavison/sumatra/pull-request/33/). As part of that work, the classes `Record` and `DataKey` were changed to have a one-to-many instead of many-to-many relationship (i.e. each data file must have been created by one, and only one, computation).

The problem with this change was the situation where computation 2 overwrites a file created by computation 1, but with identical contents. We wish to distinguish these two files, even though the first was destroyed by the creation of the second. However, the path and digest are not sufficient to distinguish the files, therefore this PR adds the creation date-time as an additional attribute of `DataKey`.

This change is backwards compatible, since previous computations have `creation` set to `None`, although you will still need to update your record store, i.e. run

```
smt export
```

with your current version of Sumatra, then

```
smt upgrade
```

after having installed the version from this PR.
