### PR TITLE
Remove dependency on mercurial

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ jinja2
 docutils
 parameters
 # optional requirements, depending on which version control systems you use
-mercurial
+hgapi
 GitPython>=0.3.6
 bzr
 # optional requirements, depending on which serialization formats you want

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     install_requires = ['Django>=1.4, <=1.6.11', 'django-tagging', 'httplib2',
                         'docutils', 'jinja2', 'parameters'],
     extras_require = {'svn': 'pysvn',
-                      'hg': 'mercurial',
+                      'hg': 'hgapi',
                       'git': 'GitPython',
                       'bzr': 'bzr',
                       'mpi': 'mpi4py'}

--- a/test/unittests/test_versioncontrol.py
+++ b/test/unittests/test_versioncontrol.py
@@ -265,14 +265,14 @@ class TestMercurialRepository(unittest.TestCase, BaseTestRepository):
         os.unlink("%s/.hg" % self.repository_path)
 
     def _create_repository(self):
-        return MercurialRepository("file://%s" % self.repository_path)
+        return MercurialRepository(self.repository_path)
 
-    def test__init(self):
-        r = self._create_repository()
-        self.assertEqual(r._repository.url(), "file:%s" % self.repository_path)
+    #def test__init(self):
+    #    r = self._create_repository()
+    #    self.assertEqual(r._repository.url(), "file:%s" % self.repository_path)
 
     def test__exists__with_nonexistent_repos__should_return_False(self):
-        repos = MercurialRepository("file:///tmp/")
+        repos = MercurialRepository("/tmp/")
         self.assertFalse(repos.exists)
 
     def test__can_create_project_in_subdir(self):

--- a/test/unittests/test_versioncontrol.py
+++ b/test/unittests/test_versioncontrol.py
@@ -115,6 +115,9 @@ class TestMercurialWorkingCopy(unittest.TestCase, BaseTestWorkingCopy):
                                         'subpackage/__init__.py',
                                         'subpackage/somemodule.py'])})
 
+    def test__returns_user(self):
+        self.assertEqual(self.wc.get_username(), "")
+
 
 #@unittest.skipUnless(have_git, "Could not import git") #
 class TestGitWorkingCopy(unittest.TestCase, BaseTestWorkingCopy):
@@ -265,14 +268,14 @@ class TestMercurialRepository(unittest.TestCase, BaseTestRepository):
         os.unlink("%s/.hg" % self.repository_path)
 
     def _create_repository(self):
-        return MercurialRepository(self.repository_path)
+        return MercurialRepository("file://%s" % self.repository_path)
 
-    #def test__init(self):
-    #    r = self._create_repository()
-    #    self.assertEqual(r._repository.url(), "file:%s" % self.repository_path)
+    def test__init(self):
+        r = self._create_repository()
+        self.assertEqual(r.url, "file://%s" % self.repository_path)
 
     def test__exists__with_nonexistent_repos__should_return_False(self):
-        repos = MercurialRepository("/tmp/")
+        repos = MercurialRepository("file:///tmp/")
         self.assertFalse(repos.exists)
 
     def test__can_create_project_in_subdir(self):

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py26, py27
 deps =
     nose
     twill
-    Mercurial
+    hgapi
     numpy
     argparse
 changedir = {toxinidir}/test/unittests


### PR DESCRIPTION
As ``mercurial`` [won't migrate to Python 3 anytime soon](http://mercurial.selenic.com/wiki/Python3), this is one step to make ``sumatra`` compatible with Python 3, #40.

I'm not really a Mercurial user by myself and the documentation of ``mercurial`` was not always very clear (in contrast to ``hgapi``by the way), so maybe you want to test this change more intensively.