### PR TITLE
Read unspecified develop versions like 0.9.0.dev

### DIFF
--- a/sumatra/programs.py
+++ b/sumatra/programs.py
@@ -42,7 +42,7 @@ from .compatibility import string_type
 from .core import run, registry
 
 
-version_pattern = re.compile(r'\b(?P<version>\d[\.\d]*([a-z]*\d)*)\b')
+version_pattern = re.compile(r'\b(?P<version>\d+(\.\d+){1,2}(\.?[a-z]+\d?)?)\b')
 version_pattern_matlab = re.compile(r'(?<=SMT_DETECT_MATLAB_VERSION=)(?P<version>\d.+)\b')
 
 

--- a/test/unittests/test_programs.py
+++ b/test/unittests/test_programs.py
@@ -17,7 +17,7 @@ from sumatra.programs import Executable, version_pattern, get_executable, \
                              RExecutable
 
 class TestVersionRegExp(unittest.TestCase):
-    
+
     def test_common_cases(self):
         examples = {
             "NEURON -- Release 7.1 (359:7f113b76a94b) 2009-10-26": "7.1",
@@ -26,7 +26,11 @@ class TestVersionRegExp(unittest.TestCase):
             "abcdefg": None,
             "usage: ls [-ABCFGHLPRSTWabcdefghiklmnopqrstuwx1] [file ...]": None,
             "4.2rc3": "4.2rc3",
-            "R scripting front-end version 3.1.2 (2014-10-31)" : "3.1.2",
+            "R scripting front-end version 3.1.2 (2014-10-31)": "3.1.2",
+            "First version that reads numbers from 0..1": None,
+            "Mature Tool 12.10": "12.10",
+            "Beta Tool 0.9.0.dev": "0.9.0.dev",
+            "Another Tool 0.8.4.Clumsy message.": "0.8.4"
         }
         for input, output in examples.items():
             match = version_pattern.search(input)
@@ -35,20 +39,20 @@ class TestVersionRegExp(unittest.TestCase):
             else:
                 version = None
             self.assertEqual(version, output)
-            
+
 
 class TestExecutable(unittest.TestCase):
-    
+
     def test__init__with_a_full_path_should_just_set_it(self):
         prog = Executable("/bin/ls")
         self.assertEqual(prog.path, "/bin/ls")
-    
+
     @unittest.skipUnless(check_output, "test requires Python 2.7")
     def test__init__with_only_prog_name__should_try_to_find_full_path(self):
         prog = Executable("ls")
         actual_path = check_output("which ls", shell=True).decode('utf-8').strip()
         self.assertEqual(prog.path, actual_path)
-        
+
     def test__init__should_find_version_if_possible(self):
         #prog = Executable("/bin/ls")
         #self.assertEqual(prog.version, None) # this is true on Darwin, but not on Ubuntu
@@ -80,10 +84,10 @@ class MockParameterSet(object):
     saved = False
     def save(self, filename, add_extension=False):
         self.saved = True
-        
+
 
 class TestPythonExecutable(unittest.TestCase):
-    
+
     def test__write_parameters__should_call_save_on_the_parameter_set(self):
         prog = PythonExecutable(None)
         params = MockParameterSet()
@@ -92,7 +96,7 @@ class TestPythonExecutable(unittest.TestCase):
 
 
 class TestModuleFunctions(unittest.TestCase):
-    
+
     def test__get_executable__with_path_of_registered_executable(self):
         prog = get_executable("/usr/bin/python")
         assert isinstance(prog, PythonExecutable)
@@ -102,12 +106,12 @@ class TestModuleFunctions(unittest.TestCase):
         if os.path.exists("/usr/bin/Rscript"):
             prog = get_executable("/usr/bin/Rscript")
             assert isinstance(prog, RExecutable)
-            
+
     def test__get_executable__with_path_of_unregistered_executable(self):
         prog = get_executable("/bin/cat")
         assert isinstance(prog, Executable)
         self.assertEqual(prog.name, "cat")
-        
+
     def test__get_executable__with_script_file(self):
         prog = get_executable(script_file="test.py")
         assert isinstance(prog, PythonExecutable)
@@ -118,7 +122,7 @@ class TestModuleFunctions(unittest.TestCase):
 
     def test__get_executable__with_nonregistered_extension__should_raise_Exception(self):
         self.assertRaises(Exception, get_executable, script_file="test.foo")
-        
+
     def test__get_executable__requires_at_least_one_arg(self):
         self.assertRaises(Exception, get_executable)
 


### PR DESCRIPTION
For executables that one maintains, one might execute simulations
of a not released development version like ``0.9.0.dev``.

While probably one _should not_ do this, sumatra should infer the
version number properly in any case. So far it read ``0.9.0.``. With
this change it reads the whole version string.