### PR TITLE
[Issue #252] Fixed issue that causes exception when path=None.

### DIFF
--- a/sumatra/versioncontrol/_subversion.py
+++ b/sumatra/versioncontrol/_subversion.py
@@ -30,7 +30,7 @@ class SubversionWorkingCopy(WorkingCopy):
 
     def __init__(self, path=None):
         WorkingCopy.__init__(self, path)
-        self.path = os.path.realpath(path)
+        self.path = os.path.realpath(self.path)
         client = pysvn.Client()
         try:
             url = client.info(self.path).url


### PR DESCRIPTION
This is my first ever pull request so please be nice (my apologies if I've done anything incorrectly).

This is to fix the issue in https://github.com/open-research/sumatra/issues/252, which is a very simple issue that breaks the subversion module when path=None is provided. This was originally changed in https://github.com/open-research/sumatra/commit/2ec101c426dac169d81abc41259438c3a6bd66a7#commitcomment-11515208, I don't know the reason for that change so I don't know if my fix is acceptable or not, but I figured might as well send it in as it's working for me.