### PR TITLE
fix: catching OSError for long parameters

### DIFF
--- a/sumatra/parameters.py
+++ b/sumatra/parameters.py
@@ -254,7 +254,7 @@ class SimpleParameterSet(ParameterSet):
         try:
             path = Path(path.__str__())
             return path.exists() and path.is_file()
-        except TypeError:
+        except (TypeError, OSError):
             return False
 
     @classmethod

--- a/test/unittests/test_parameters.py
+++ b/test/unittests/test_parameters.py
@@ -228,8 +228,8 @@ class TestSimpleParameterSet(unittest.TestCase):
         self.assertEqual(P1.diff(P3),
                          ({'y': 3}, {'y': 4, 'z': 4}))
 
-    def test_long_paramter(self):
-        parameters = "x = '" + ''.join(["a" for unused in range(250)]) + "'"
+    def test_long_parameter(self):
+        parameters = "x = '{0}'".format(''.join("a" * 250))
         SimpleParameterSet(parameters)
 
 

--- a/test/unittests/test_parameters.py
+++ b/test/unittests/test_parameters.py
@@ -228,6 +228,10 @@ class TestSimpleParameterSet(unittest.TestCase):
         self.assertEqual(P1.diff(P3),
                          ({'y': 3}, {'y': 4, 'z': 4}))
 
+    def test_long_paramter(self):
+        parameters = "x = '" + ''.join(["a" for unused in range(250)]) + "'"
+        SimpleParameterSet(parameters)
+
 
 class TestConfigParserParameterSet(unittest.TestCase):
     test_parameters = dedent("""

--- a/tox.ini
+++ b/tox.ini
@@ -20,11 +20,11 @@ deps =
     pathlib
 
 [testenv:py27]
-    deps =
+deps =
     {[testenv]deps}
     pathlib
 
 [testenv:py33]
-    deps =
+deps =
     {[testenv]deps}
     pathlib


### PR DESCRIPTION
fixes #259