### PR TITLE
Fix #268 by converting Py2 str to unicode-like

### DIFF
--- a/sumatra/decorators.py
+++ b/sumatra/decorators.py
@@ -13,6 +13,7 @@ def main(parameters, [other_args...]):
 """
 from __future__ import unicode_literals
 
+from builtins import str
 import time
 from sumatra.programs import PythonExecutable
 import sys
@@ -21,10 +22,20 @@ import contextlib
 from io import StringIO
 
 
+class _ByteAndUnicodeStringIO(StringIO):
+    """A StringIO subclass accepting `str` in Py2 and `str` in Py3.
+
+    The io.StringIO implementation does not accept Py2 `str`.
+    """
+
+    def write(self, object):
+        StringIO.write(self, str(object))
+
+
 @contextlib.contextmanager
 def _grab_stdout_stderr():
     try:
-        output = StringIO()
+        output = _ByteAndUnicodeStringIO()
         sys.stdout, sys.stderr = output, output
         yield output
     finally:


### PR DESCRIPTION
``io.StringIO`` does not accept Py2 ``str``, hence the strings from stdout must be wrapped in Py2.

Fixes #268.