### PR TITLE
smtweb: displaying linebreaks in stdout_stderr

### DIFF
--- a/sumatra/web/templates/record_detail.html
+++ b/sumatra/web/templates/record_detail.html
@@ -298,7 +298,7 @@
         </h4>
     </div>
     <div id="stdout-stderr-panel" class="panel-body collapse in">
-      <code>{{ record.stdout_stderr }}</code>
+      <code>{{ record.stdout_stderr | linebreaksbr }}</code>
     </div>
 </div>
 {% endif %}


### PR DESCRIPTION
Currently, ``smtweb`` does not show any linebreaks in ``stdout_stderr``. This is changed within this pr.