### PR TITLE
Better handling of unknown mime types when downloading (cf #274)

### DIFF
--- a/sumatra/web/templates/data_detail_base.html
+++ b/sumatra/web/templates/data_detail_base.html
@@ -15,7 +15,7 @@
 
 <div class="panel panel-info">
     <div class="panel-heading">
-        <h2 class="panel-title">{{data_key.path}} <small>{{data_key.digest}}</small> {{data_key.get_metadata.mimetype}} {{data_key.get_metadata.size|filesizeformat}}</h2>
+        <h2 class="panel-title">{{data_key.path}} <small>{{data_key.digest}}</small> {{data_key.get_metadata.mimetype|default_if_none:"unknown"}} {{data_key.get_metadata.size|filesizeformat}}</h2>
     </div>
     <div class="panel-body">
 
@@ -36,5 +36,5 @@
     <p>File contents truncated. <a href="/{{project_name}}/data/datafile?path={{data_key.path|urlencode}}&digest={{data_key.digest}}&creation={{data_key.creation|date:"c"}}&truncate=false" class="btn btn-default">Show entire contents</a></p>
 {% endif %}
 
-<p><a href="/data/{{datastore_id}}?path={{data_key.path|urlencode}}&digest={{data_key.digest}}&creation={{data_key.creation|date:"c"}}" class="btn btn-default">Download</a></p>
+<p><a href="/data/{{datastore_id}}?path={{data_key.path|urlencode}}&digest={{data_key.digest}}&creation={{data_key.creation|date:"c"}}" class="btn btn-default" type="{{data_key.get_metadata.mimetype|default_if_none:"application/unknown"}}" download="{{data_key.path}}">Download</a></p>
 {% endblock content %}

--- a/sumatra/web/views.py
+++ b/sumatra/web/views.py
@@ -250,7 +250,7 @@ def show_content(request, datastore_id):
         content = datastore.get_content(data_key)
     except (IOError, KeyError):
         raise Http404
-    return HttpResponse(content, content_type=mimetype)
+    return HttpResponse(content, content_type=mimetype or "application/unknown")
 
 
 def compare_records(request, project):


### PR DESCRIPTION
Added download attribute, so browsers (except Safari and IE) get a sensible filename.