### PR TITLE
Fix error in Python2 when setting FileSystemDataStore.root with a subclass of string

### DIFF
--- a/sumatra/datastore/filesystem.py
+++ b/sumatra/datastore/filesystem.py
@@ -88,7 +88,11 @@ class FileSystemDataStore(DataStore):
         return self._root
 
     def __set_root(self, value):
-        path = Path(value)
+        try:
+            path = Path(value)
+        except TypeError:
+            # This can happen in Python2 if 'value' is a subclass of string
+            path = Path(unicode(value))
         self._root = value
         if not path.exists():
             try:

--- a/test/unittests/test_datastore.py
+++ b/test/unittests/test_datastore.py
@@ -43,6 +43,13 @@ class TestFileSystemDataStore(unittest.TestCase):
     def test__str__should_return_root(self):
         self.assertEqual(str(self.ds), self.root_dir)
 
+    def test__setting_root_with_str_should_work(self):
+        # This is a regression test for Python2 where str(...) returns an instance
+        # of type 'future.types.newstr.newstr' which makes Pathlib choke if passed
+        # directly (because it tries to intern the string). Here we check that the
+        # class FileSystemDataStore knows how to deal with this.
+        self.ds.root = str('/tmp/foo/bar')
+
     def test__get_state__should_return_dict_containing_root(self):
         self.assertEqual(self.ds.__getstate__(), {'root': self.root_dir})
 


### PR DESCRIPTION
This fixes #287.