### PR TITLE
Use absolute path to avoid 'os.path.dirname(p)' returning an empty string

### DIFF
--- a/sumatra/projects.py
+++ b/sumatra/projects.py
@@ -462,7 +462,7 @@ def load_project(path=None):
     if not path:
         p = os.getcwd()
     else:
-        p = path
+        p = os.path.abspath(path)
     while not os.path.isdir(os.path.join(p, ".smt")):
         oldp, p = p, os.path.dirname(p)
         if p == oldp:


### PR DESCRIPTION
This fixes #291.