### PR TITLE
Restore the diff view in the web interface

### DIFF
--- a/sumatra/web/templates/diff_view.html
+++ b/sumatra/web/templates/diff_view.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% load filters %}
+
+{% block title %}{{project_name}}: {{label}}: Difference in {{package}}{% endblock %}
+
+{% block navbar %}
+            <li><a href="..">{{project_name}}</a></li>
+            <li><a href="/{{project_name}}/{{label}}/"> {{label}}</a></li>
+            <li><a href="#">Diff</a></li>
+{% endblock %}
+
+{% block content %}
+
+<div class="panel panel-info">
+    <div class="panel-heading">
+        <h2 class="panel-title">{{package}}: Difference between the code used in {{label}} and version {{parent_version}}</h2>
+    </div>
+    <div class="panel-body">
+    <code>
+    {{diff|escape|linebreaksbr}}
+    </code>
+    </div>
+</div>
+
+{% endblock %}

--- a/sumatra/web/urls.py
+++ b/sumatra/web/urls.py
@@ -12,7 +12,7 @@ from sumatra.projects import Project
 from sumatra.records import Record
 from sumatra.web.views import (ProjectListView, ProjectDetailView, RecordListView,
                                RecordDetailView, DataListView, DataDetailView,
-                               SettingsView)
+                               SettingsView, DiffView)
 
 P = {
     'project': Project.valid_name_pattern,
@@ -29,6 +29,8 @@ urlpatterns = patterns('',
                        (r'^%(project)s/delete/$' % P, 'sumatra.web.views.delete_records'),
                        (r'^%(project)s/compare/$' % P, 'sumatra.web.views.compare_records'),
                        (r'^%(project)s/%(label)s/$' % P, RecordDetailView.as_view()),
+                       (r'^%(project)s/%(label)s/diff$' % P, DiffView.as_view()),
+                       (r'^%(project)s/%(label)s/diff/(?P<package>[\w_]+)*$' % P, DiffView.as_view()),
                        (r'^%(project)s/data/datafile$' % P, DataDetailView.as_view()),
                        (r'^data/(?P<datastore_id>\d+)$', 'sumatra.web.views.show_content'),
                        )


### PR DESCRIPTION
This was accidentally removed during the cleanup of `sumatra.web` prior to the 0.7 release.