### PR TITLE
Allow other basic Python types when updating parameters

### DIFF
--- a/sumatra/parameters.py
+++ b/sumatra/parameters.py
@@ -297,8 +297,11 @@ class SimpleParameterSet(ParameterSet):
             or (stripped.startswith(double_quote) and stripped.endswith(double_quote))
 
     def _add_or_update_parameter(self, name, value, comment=None):
-        if not isinstance(value, (int, float, str, list)):
-            raise TypeError("value must be a numeric value or a string")
+        # Technically, bool is a subtype of int but we list it explicitly for clarity.
+        # TODO: Should we check for and disallow nested lists/tuples?
+        if value is not None and not isinstance(value, (int, float, str, bool, list, tuple)):
+            raise TypeError("Value must be one of the basic types (a numeric value, bool, "
+                "string, list, tuple or None. Got: '{}' ({})".format(value, type(value)))
         self.values[name] = value
         self.types[name] = type(value)
         if comment is not None:

--- a/test/unittests/test_parameters.py
+++ b/test/unittests/test_parameters.py
@@ -187,14 +187,24 @@ class TestSimpleParameterSet(unittest.TestCase):
         os.remove("test_file")
         os.remove("test_file.orig")
 
-    def test__update__should_only_accept_numbers_or_strings(self):
-        # could maybe allow lists of numbers or strings
+    def test__update__should_accept_basic_python_types(self):
         P = SimpleParameterSet("x = 2\ny = 3")
-        P.update({"z": "hello"})
-        self.assertEqual(P["z"], "hello")
-        P.update({"tumoltuae": 42})
-        self.assertEqual(P["tumoltuae"], 42)
-        self.assertRaises(TypeError, P.update, "bar", {})
+        param_values = [("z", "hello"),
+                        ("tumoltuae", 42),
+                        ("somelist", [1, 2, "a", "b"]),
+                        ("sometuple", (3, 4, "c")),
+                        ("foo", None),
+                        ("isittrue", False)]
+        for name, value in param_values:
+            P.update({name: value})
+            self.assertEqual(P[name], value)
+
+    def test__update__should_not_accept_complex_types(self):
+        class CustomClass(object):
+            pass
+        P = SimpleParameterSet("x = 2\ny = 3")
+        self.assertRaises(TypeError, P.update, "somedict", {})
+        self.assertRaises(TypeError, P.update, "someclass", CustomClass())
 
     def test__update_kwargs(self):
         P = SimpleParameterSet("x = 2\ny = 3")


### PR DESCRIPTION
I regularly need to use parameters that can take a tuple or `None` as value, which currently isn't possible.