### PR TITLE
Added capture_args decorator to capture the arguments of a function as the parameter set.

### DIFF
--- a/sumatra/decorators.py
+++ b/sumatra/decorators.py
@@ -4,7 +4,7 @@ Decorators to make it easier to use Sumatra in your own Python scripts.
 Usage:
 
 @capture
-def main(parameters, [other_args...]):
+def main([parameters and other args...]):
     <body of main function>
 
 
@@ -16,7 +16,7 @@ from __future__ import unicode_literals
 from builtins import str
 import time
 from sumatra.programs import PythonExecutable
-from sumatra.parameters import SimpleParameterSet
+from sumatra.parameters import ParameterSet, SimpleParameterSet
 import sys
 import os
 import contextlib
@@ -47,9 +47,32 @@ def _grab_stdout_stderr():
 def capture(main):
     """
     Decorator for a main() function, which will create a new record for this
-    execution. The first argument of main() must be a parameter set.
+    execution.
+
+    The arguments of main can be recorded as parameters for this execution:
+    * If the first (un-named) argument is a ParameterSet, or there is a named
+      argument "parameters" containing a ParameterSet, then that is recorded.
+    * Otherwise, all arguments to the function are packaged into a 
+      SimpleParameterSet. This assumes all arguments are basic types 
+      (i.e. str, float, int, etc.), otherwise an exception will be raised.
+    
+    The first argument of main() must be a parameter set.
     """
-    def wrapped_main(parameters, *args, **kwargs):
+    def wrapped_main(*args, **kwargs):
+
+        if len(args) > 0 and isinstance(args[0], ParameterSet):
+            # If the first argument is a ParameterSet
+            parameters = args[0]
+        elif len(kwargs) > 0 and "parameters" in kwargs \
+                and isinstance(kwargs["parameters"], ParameterSet):
+            # If there is a named "parameters" argument
+            parameters = kwargs["parameters"]
+        else:
+            # Package all parameters into a SimpleParameterSet
+            parameters = dict(zip(["arg%d" % x for x in range(len(args))], args))
+            parameters.update(kwargs)
+            parameters = SimpleParameterSet(parameters)
+
         import sumatra.projects
         project = sumatra.projects.load_project()
         main_file = sys.modules['__main__'].__file__
@@ -61,34 +84,11 @@ def capture(main):
         parameters.update({"sumatra_label": record.label})
         start_time = time.time()
         with _grab_stdout_stderr() as stdout_stderr:
-            main(parameters, *args, **kwargs)
+            main(*args, **kwargs)
             record.stdout_stderr = stdout_stderr.getvalue()
         record.duration = time.time() - start_time
         record.output_data = record.datastore.find_new_data(record.timestamp)
         project.add_record(record)
         project.save()
-
-    return wrapped_main
-
-def capture_args(main):
-    """
-    Decorator for a main() function, which will create a new record for this
-    execution.
-
-    The arguments of main() will be considered the parameter set. This assumes
-    all arguments are basic types (i.e. they get passed to SimpleParameterSet).
-    """
-    def wrapped_main(*args, **kwargs):
-        parameters = dict(zip(["arg%d" % x for x in range(len(args))], args))
-        parameters.update(kwargs)
-        parameters = SimpleParameterSet(parameters)
-
-        @capture
-        def fake_main(param, *args, **kwargs):
-            # Discard parameters
-            main(*args, **kwargs)
-
-        # Run the fake main to discard the parameters
-        fake_main(parameters, *args, **kwargs)
 
     return wrapped_main


### PR DESCRIPTION
This is probably not something that's necessarily desired in Sumatra, and I haven't exhaustively tested or anything, but I thought it might be worth giving the devs the option to pull if you guys want to work with it.

Basically copies the @capture decorator (new @capture_args decorator) that, rather than expecting a parameter set as an argument to the function, just considers the arguments to the function to be the parameter set (i.e. it packages the arguments within a SimpleParameterSet, so the arguments must be basic types). 

I just wanted more convenience than having to create a parameter set out of my arguments from within my own code, I'd rather have everything "just work".