### PR TITLE
Updated GitPython requirement to 1.0.1, and fixed issue in finderepo().

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -8,7 +8,7 @@ parameters
 future
 # optional requirements, depending on which version control systems you use
 hgapi
-GitPython>=0.3.6
+GitPython>=1.0.1
 # optional requirements, depending on which serialization formats you want
 pyyaml
 # optional, for WebDAV support

--- a/sumatra/versioncontrol/_git.py
+++ b/sumatra/versioncontrol/_git.py
@@ -39,7 +39,7 @@ def check_version():
         raise VersionControlError(
             "GitPython not installed. There is a 'git' package, but it is not "
             "GitPython (https://pypi.python.org/pypi/GitPython/)")
-    minimum_version = '0.3.5'
+    minimum_version = '1.0.1'
     if LooseVersion(git.__version__) < LooseVersion(minimum_version):
         raise VersionControlError(
             "Your Git Python binding is too old. You require at least "
@@ -54,7 +54,7 @@ def findrepo(path):
     except InvalidGitRepositoryError:
         return
     else:
-        return os.path.dirname(repo.git_dir)
+        return repo.working_dir
 
 
 @component


### PR DESCRIPTION
Making a pull request in case this is useful to the developers. I haven't exhaustively tested or anything. Commit message below:

"An issue arose from this situation: There is a git repository MyLibs,
containing within it a list of git submodules (MyLib1, MyLib2, etc.).
Each of these is a Python module/package, so each could be used by
import MyLib1, import MyLib2, and so on. When sumatra checked the
dependencies, it would look at each of MyLib1, MyLib2, etc. and find
that their .git directories were stored as MyLibs/.git/modules/MyLib1,
for example. This meant that sumatra believed the root of each of
these modules to be the directory MyLibs/.git/modules, which is
clearly not the case.

This commit fixes the issue by basically returning the working
directory of the repository, which is either the root of the working
tree, or the .git repository if it is a bare repo. Since I don't know
what version this was introduced in, I've updated the requirement for
gitpython to 1.0.1, which I believe is the latest.

It's possible I misunderstood the purpose of findrepo(), in which case
this is not a valid fix. Another potential fix might be to check
whether repo.has_separate_working_tree(), and if so, return
repo.working_tree_dir."

Alternatively, someone with a better understanding of what findrepo() should be doing should ensure that the code uses the latest gitpython features in order to avoid situations like mine above.
