### PR TITLE
filter records by parameter values in API and CLI

### DIFF
--- a/sumatra/commands.py
+++ b/sumatra/commands.py
@@ -54,6 +54,17 @@ def _warning(
     print(message)
 warnings.showwarning = _warning
 
+def _convertStr(s):
+ 	"""Convert string to either int or float or not both."""
+ 	try:
+ 		ret = int(s)
+ 	except ValueError:
+         try:
+             ret = float(s)
+         except ValueError:
+             ret = s
+ 	return ret
+
 def parse_executable_str(exec_str):
     """
     Split the string describing the executable into a path part and an
@@ -433,6 +444,7 @@ def list(argv):  # add 'report' and 'log' as aliases
     parser.add_argument('-m', '--main_file', help="filter list of records by main file")
     parser.add_argument('-P', '--parameter_table', action="store_const", const="parameter_table",
                         dest="mode", help="list records with parameter values")
+    parser.add_argument('-p', '--parameters', metavar='parameters', default=None, help="filter records by parameter values, separated by comma")
     args = parser.parse_args(argv)
 
     project = load_project()
@@ -442,6 +454,14 @@ def list(argv):  # add 'report' and 'log' as aliases
 
     kwargs = {'tags':args.tags, 'mode':args.mode, 'format':args.format, 'reverse':args.reverse}
     if args.main_file is not None: kwargs['main_file__startswith'] = args.main_file
+    if args.parameters:
+        parameters = {}
+        for pp in args.parameters.split(','):
+            for operator in ['=',':']:
+                if operator in pp:
+                    pkey,pval = pp.split(operator)
+                    parameters.update({pkey:_convertStr(pval)})
+        kwargs.update({'parameters':parameters})
     print(project.format_records(**kwargs))
 
 

--- a/sumatra/projects.py
+++ b/sumatra/projects.py
@@ -296,16 +296,18 @@ class Project(object):
             labels.reverse()
         return labels
 
-    def find_records(self, tags=None, reverse=False, *args, **kwargs):
+    def find_records(self, tags=None, reverse=False, parameters=None, *args, **kwargs):
         records = self.record_store.list(self.name, tags, *args, **kwargs)
         if reverse:
             records.reverse()
+        if parameters is not None:
+            records = [rec for rec in records if len(rec.parameters.diff(parameters)[-1]) == 0]
         return records
 
     # def find_data() here?
 
     def format_records(self, format='text', mode='short', tags=None, reverse=False, *args, **kwargs):
-        if format=='text' and mode=='short':
+        if format=='text' and mode=='short' and ('parameters' not in kwargs.keys()):
             return '\n'.join(self.get_labels(tags=tags, reverse=reverse))
         else:
             records = self.find_records(tags=tags, reverse=reverse, *args, **kwargs)


### PR DESCRIPTION
The idea of this PR is to find records more efficiently if the list of records is filtered by a or several parameter values. You can test it in terminal: 

``` bash
smt list -p pkey=pval
smt list -p pkey:pval
```

or in API: 

``` python
from sumatra.projects import load_project
p = load_project()
p.find_records(parameters={pkey:pval})
```
