### PR TITLE
Extend length of Dependency.version to accomodate git SHA

### DIFF
--- a/sumatra/recordstore/django_store/models.py
+++ b/sumatra/recordstore/django_store/models.py
@@ -106,7 +106,7 @@ class Executable(BaseModel):
 class Dependency(BaseModel):
     name = models.CharField(max_length=50)
     path = models.CharField(max_length=200)
-    version = models.CharField(max_length=20)
+    version = models.CharField(max_length=40)
     diff = models.TextField(blank=True)
     source = models.CharField(max_length=200, null=True, blank=True)
     module = models.CharField(max_length=50)  # should be called language, or something


### PR DESCRIPTION
If the store is in PostgreSQL and the version control is git, Sumatra raises an error (or would if not for the exception handling in `project.add_record`) because `Dependency.version` isn't large enough to hold a SHA:
```python
Traceback (most recent call last):
  File "/Users/guyer/anaconda/envs/parallel/bin/smt", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/Users/guyer/Documents/Python/sumatra/bin/smt", line 31, in <module>
    main(sys.argv[2:])
  File "/Users/guyer/Documents/Python/sumatra/sumatra/commands.py", line 401, in run
    version=args.version or 'current')
  File "/Users/guyer/Documents/Python/sumatra/sumatra/projects.py", line 222, in launch
    self.add_record(record)
  File "/Users/guyer/Documents/Python/sumatra/sumatra/projects.py", line 261, in add_record
    self.record_store.save(self.name, record)
  File "/Users/guyer/Documents/Python/sumatra/sumatra/recordstore/django_store/__init__.py", line 249, in save
    db_record.dependencies.add(self._get_db_obj('Dependency', dep))
  File "/Users/guyer/Documents/Python/sumatra/sumatra/recordstore/django_store/__init__.py", line 206, in _get_db_obj
    db_obj, created = cls.objects.get_or_create_from_sumatra_object(obj, using=self._db_label)
  File "/Users/guyer/Documents/Python/sumatra/sumatra/recordstore/django_store/models.py", line 53, in get_or_create_from_sumatra_object
    return self.using(using).get_or_create(**attributes)
  File "/Users/guyer/anaconda/envs/parallel/lib/python2.7/site-packages/Django-1.8.8-py2.7.egg/django/db/models/query.py", line 407, in get_or_create
    return self._create_object_from_params(lookup, params)
  File "/Users/guyer/anaconda/envs/parallel/lib/python2.7/site-packages/Django-1.8.8-py2.7.egg/django/db/models/query.py", line 439, in _create_object_from_params
    obj = self.create(**params)
  File "/Users/guyer/anaconda/envs/parallel/lib/python2.7/site-packages/Django-1.8.8-py2.7.egg/django/db/models/query.py", line 348, in create
    obj.save(force_insert=True, using=self.db)
  File "/Users/guyer/anaconda/envs/parallel/lib/python2.7/site-packages/Django-1.8.8-py2.7.egg/django/db/models/base.py", line 734, in save
    force_update=force_update, update_fields=update_fields)
  File "/Users/guyer/anaconda/envs/parallel/lib/python2.7/site-packages/Django-1.8.8-py2.7.egg/django/db/models/base.py", line 762, in save_base
    updated = self._save_table(raw, cls, force_insert, force_update, using, update_fields)
  File "/Users/guyer/anaconda/envs/parallel/lib/python2.7/site-packages/Django-1.8.8-py2.7.egg/django/db/models/base.py", line 846, in _save_table
    result = self._do_insert(cls._base_manager, using, fields, update_pk, raw)
  File "/Users/guyer/anaconda/envs/parallel/lib/python2.7/site-packages/Django-1.8.8-py2.7.egg/django/db/models/base.py", line 885, in _do_insert
    using=using, raw=raw)
  File "/Users/guyer/anaconda/envs/parallel/lib/python2.7/site-packages/Django-1.8.8-py2.7.egg/django/db/models/manager.py", line 127, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/Users/guyer/anaconda/envs/parallel/lib/python2.7/site-packages/Django-1.8.8-py2.7.egg/django/db/models/query.py", line 920, in _insert
    return query.get_compiler(using=using).execute_sql(return_id)
  File "/Users/guyer/anaconda/envs/parallel/lib/python2.7/site-packages/Django-1.8.8-py2.7.egg/django/db/models/sql/compiler.py", line 974, in execute_sql
    cursor.execute(sql, params)
  File "/Users/guyer/anaconda/envs/parallel/lib/python2.7/site-packages/Django-1.8.8-py2.7.egg/django/db/backends/utils.py", line 79, in execute
    return super(CursorDebugWrapper, self).execute(sql, params)
  File "/Users/guyer/anaconda/envs/parallel/lib/python2.7/site-packages/Django-1.8.8-py2.7.egg/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File "/Users/guyer/anaconda/envs/parallel/lib/python2.7/site-packages/Django-1.8.8-py2.7.egg/django/db/utils.py", line 98, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "/Users/guyer/anaconda/envs/parallel/lib/python2.7/site-packages/Django-1.8.8-py2.7.egg/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
django.db.utils.DataError: value too long for type character varying(20)
```