### PR TITLE
Record status while in progress

### DIFF
--- a/doc/command_reference.txt
+++ b/doc/command_reference.txt
@@ -401,16 +401,18 @@ tag
 ::
 
     usage: smt tag [options] TAG [LIST]
-    
+
     If TAG contains spaces, it must be enclosed in quotes. LIST should be a space-
     separated list of labels for individual records. If it is omitted, only the
     most recent record will be tagged. If the '-r/--remove' option is set, the tag
-    will be removed from the records.
-    
+    will be removed from the records. TAG can be a status from the mutually
+    exclusive list: _initialized_, _pre_run_, _running_, _finished_, _failed_,
+    _killed_, _succeeded_, _crashed_.
+
     positional arguments:
       TAG           tag to add
       LIST          a space-separated list of records to be tagged
-    
+
     optional arguments:
       -h, --help    show this help message and exit
       -r, --remove  remove the tag from the record(s), rather than adding it.
@@ -437,4 +439,3 @@ version
     
     optional arguments:
       -h, --help  show this help message and exit
-

--- a/doc/getting_started.txt
+++ b/doc/getting_started.txt
@@ -61,7 +61,7 @@ use the ``--long`` option::
     Launch_Mode      : serial
     Output_Data      : [example2.dat(43a47cb379df2a7008fdeb38c6172278d000fdc4)]
     User             : Arthur Dent <dent@example.com>
-    Tags             :
+    Tags             : _finished_
     Repeats          : None
     
 (most options also have a short form, ``-l`` in this case.)
@@ -125,6 +125,21 @@ and remove tags::
 
     $ smt tag --remove barfoo
 
+During the execution of ``smt run``, the tag will be automatically marked
+with a status that progresses through ``_initialized_``, ``_pre_run_``, and
+``_running_``. Upon completion, status will be set to ``_finished_`` or
+``_failed_``. If the status is ``_failed_``, the outcome field will reflect
+the return code. If you terminate the run early with ``control-C``, the
+status will be ``_killed_``. You can manually assign the status of a
+simulation record::
+
+    $ smt tag _succeeded_
+    $ smt tag _crashed_
+
+Any of the preceeding status codes may be assigned manually, but
+``_succeeded_`` and ``_crashed_`` will never be assigned automatically, as
+they are somewhat in the eye of the beholder.
+
 The parameter file may be in any format - it is your script which is responsible
 for reading it. However, if it is in one of the :doc:`formats that Sumatra understands <parameter_files>`
 then it is possible to modify parameter values
@@ -180,6 +195,7 @@ available by running ``smt`` by itself::
       upgrade
       sync
       migrate
+      version
 
 
 and help on a given command is available by running the command with the ``--help``

--- a/sumatra/commands.py
+++ b/sumatra/commands.py
@@ -28,7 +28,7 @@ from sumatra.recordstore import get_record_store
 from sumatra.versioncontrol import get_working_copy, get_repository, UncommittedModificationsError
 from sumatra.formatting import get_diff_formatter
 from sumatra.records import MissingInformationError
-from sumatra.core import TIMESTAMP_FORMAT
+from sumatra.core import TIMESTAMP_FORMAT, STATUS_FORMAT, STATUS_PATTERN
 
 logger = logging.getLogger("Sumatra")
 logger.setLevel(logging.CRITICAL)
@@ -503,11 +503,15 @@ def comment(argv):
 def tag(argv):
     """Tag, or remove a tag, from a record or records."""
     usage = "%(prog)s tag [options] TAG [LIST]"
+    statuses = ('initialized', 'pre_run', 'running', 'finished', 'failed', 
+                'killed', 'succeeded', 'crashed')
+    formatted_statuses = ", ".join((STATUS_FORMAT % s for s in statuses))
     description = dedent("""\
       If TAG contains spaces, it must be enclosed in quotes. LIST should be a
       space-separated list of labels for individual records. If it is omitted,
       only the most recent record will be tagged. If the '-r/--remove' option
-      is set, the tag will be removed from the records.""")
+      is set, the tag will be removed from the records. TAG can be a status 
+      from the mutually exclusive list:  %s. """ % formatted_statuses)
     parser = ArgumentParser(usage=usage,
                             description=description)
     parser.add_argument('tag', metavar='TAG', help="tag to add")
@@ -515,6 +519,13 @@ def tag(argv):
     parser.add_argument('-r', '--remove', action='store_true',
                         help="remove the tag from the record(s), rather than adding it.")
     args = parser.parse_args(argv)
+
+    m = STATUS_PATTERN.match(args.tag)
+    if m:
+        tag = m.group(1).lower()
+        if tag not in statuses:
+            raise ValueError("TAG should be one of %s" % formatted_statuses)
+
     project = load_project()
     if args.remove:
         op = project.remove_tag

--- a/sumatra/core.py
+++ b/sumatra/core.py
@@ -21,9 +21,13 @@ from collections import OrderedDict
 from urllib.request import urlopen
 from urllib.error import URLError
 import warnings
+import re
 
 
 TIMESTAMP_FORMAT = "%Y%m%d-%H%M%S"
+
+STATUS_FORMAT = "_%s_"
+STATUS_PATTERN = re.compile(r"_(([^.]*)(\.\.\.)?)_")
 
 
 def have_internet_connection():

--- a/sumatra/decorators.py
+++ b/sumatra/decorators.py
@@ -20,6 +20,8 @@ import sys
 import os
 import contextlib
 from io import StringIO
+import traceback
+from sumatra.core import STATUS_FORMAT
 
 
 class _ByteAndUnicodeStringIO(StringIO):
@@ -58,12 +60,27 @@ def capture(main):
                                     executable=executable)
         record.launch_mode.working_directory = os.getcwd()
         parameters.update({"sumatra_label": record.label})
+        record.add_tag(STATUS_FORMAT % "running")
+        record.stdout_stderr = "Not yet captured."
+        project.add_record(record)
         start_time = time.time()
         with _grab_stdout_stderr() as stdout_stderr:
-            main(parameters, *args, **kwargs)
-            record.stdout_stderr = stdout_stderr.getvalue()
+            try:
+                main(parameters, *args, **kwargs)
+                status = "finished"
+            except KeyboardInterrupt:
+                status = "killed"
+            except Exception as e:
+                status = "failed"
+                record.outcome = repr(e)
+                traceback.print_exc()
+            finally:
+                record.stdout_stderr = stdout_stderr.getvalue()
+        record.add_tag(STATUS_FORMAT % (status + "..."))
+        project.save_record(record)
         record.duration = time.time() - start_time
         record.output_data = record.datastore.find_new_data(record.timestamp)
-        project.add_record(record)
+        record.add_tag(STATUS_FORMAT % status)
+        project.save_record(record)
         project.save()
     return wrapped_main

--- a/sumatra/formatting/__init__.py
+++ b/sumatra/formatting/__init__.py
@@ -556,20 +556,23 @@ def human_readable_duration(seconds):
     '8d 0.12s'
 
     """
-    from math import modf
-    (fractional_part, integer_part) = modf(seconds)
-    (d, rem) = _quotient_remainder(int(integer_part), 60 * 60 * 24)
-    (h, rem) = _quotient_remainder(rem, 60 * 60)
-    (m, rem) = _quotient_remainder(rem, 60)
-    s = rem + fractional_part
+    if seconds is None:
+        return "None"
+    else:
+        from math import modf
+        (fractional_part, integer_part) = modf(seconds)
+        (d, rem) = _quotient_remainder(int(integer_part), 60 * 60 * 24)
+        (h, rem) = _quotient_remainder(rem, 60 * 60)
+        (m, rem) = _quotient_remainder(rem, 60)
+        s = rem + fractional_part
 
-    return ' '.join(
-        templ.format(val)
-        for (val, templ) in [
-            (d, '{0}d'),
-            (h, '{0}h'),
-            (m, '{0}m'),
-            (s, '{0:.2f}s'),
-        ]
-        if val != 0
-    )
+        return ' '.join(
+            templ.format(val)
+            for (val, templ) in [
+                (d, '{0}d'),
+                (h, '{0}h'),
+                (m, '{0}m'),
+                (s, '{0:.2f}s'),
+            ]
+            if val != 0
+        )

--- a/sumatra/launch.py
+++ b/sumatra/launch.py
@@ -96,8 +96,7 @@ class LaunchMode(object):
         """
         Run a computation in a shell, with the given executable, script and
         arguments. If `append_label` is provided, it is appended to the
-        command line. Return True if the computation finishes successfully,
-        False otherwise.
+        command line. Return resultcode.
         """
         self.check_files(executable, main_file)
         cmd = self.generate_command(executable, main_file, arguments)
@@ -110,10 +109,7 @@ class LaunchMode(object):
         else:
             result, output = tee.system2(cmd, cwd=self.working_directory, stdout=True)  # cwd only relevant for local launch, not for MPI, for example
         self.stdout_stderr = "".join(output)
-        if result == 0:
-            return True
-        else:
-            return False
+        return result
 
     def __key(self):
         state = self.__getstate__()

--- a/sumatra/records.py
+++ b/sumatra/records.py
@@ -23,11 +23,12 @@ import time
 import os
 from os.path import join, basename, exists
 import re
+import signal
 from operator import or_
 from functools import reduce
 from .formatting import get_formatter
 from . import dependency_finder
-from sumatra.core import TIMESTAMP_FORMAT
+from sumatra.core import TIMESTAMP_FORMAT, STATUS_FORMAT, STATUS_PATTERN
 from sumatra.users import get_user
 from .versioncontrol import VersionControlError
 import logging
@@ -85,12 +86,14 @@ class Record(object):
         self.input_datastore = input_datastore or self.datastore
         self.outcome = ''
         self.output_data = []
-        self.tags = set()
+        self.tags = set([STATUS_FORMAT % 'initialized'])
         self.diff = diff
         self.user = user
         self.on_changed = on_changed
         self.stdout_stderr = stdout_stderr
         self.repeats = None
+        self.dependencies = []
+        self.platforms = []
 
     def register(self, working_copy):
         """Record information about the environment."""
@@ -122,7 +125,7 @@ class Record(object):
         # Record information about the current user
         self.user = get_user(working_copy)
 
-    def run(self, with_label=False):
+    def run(self, with_label=False, project=None):
         """
         Launch the simulation or analysis.
 
@@ -144,8 +147,15 @@ class Record(object):
             else:
                 raise Exception("with_label must be either 'parameters' or 'cmdline'")
             self.datastore.root = join(self.datastore.root, self.label)
+
+        self.add_tag(STATUS_FORMAT % "pre_run")
+        if project:
+            project.save_record(self)
+            logger.debug("Record saved @ pre_run.")
+
         # run pre-simulation/analysis tasks, e.g. nrnivmodl
         self.launch_mode.pre_run(self.executable)
+
         # Write the executable-specific parameter file
         script_arguments = self.script_arguments
         if self.parameters:
@@ -154,8 +164,35 @@ class Record(object):
             script_arguments = script_arguments.replace("<parameters>", self.parameter_file)
         # Run simulation/analysis
         start_time = time.time()
+
+        self.add_tag(STATUS_FORMAT % "running")
+        self.stdout_stderr = "Not yet captured."
+        if project:
+            project.save_record(self)
+            logger.debug("Record saved @ running.")
+
         result = self.launch_mode.run(self.executable, self.main_file,
                                       script_arguments, data_label)
+        if result == 0:
+            status = "finished"
+            logger.debug("  Run finished.")
+        elif result == -signal.SIGINT:
+            status = "killed"
+            logger.debug("  Run killed.")
+        else:
+            status = "failed"
+            if result < 0:
+                self.outcome = ("Failed with `returncode \
+                                <https://docs.python.org/2/library/subprocess.html\
+                                #subprocess.Popen.returncode>`_ %d" % result)
+            logger.debug("  Run failed.")
+            
+        self.add_tag(STATUS_FORMAT % (status + "..."))
+        if project:
+            project.save_record(self)
+            logger.debug("Record saved @ gathering.")
+        self.add_tag(STATUS_FORMAT % status)
+            
         self.duration = time.time() - start_time
 
         # try to get stdout_stderr from launch_mode
@@ -178,6 +215,8 @@ class Record(object):
         if self.parameters and exists(self.parameter_file):
             time.sleep(0.5) # execution of matlab: parameter_file is not always deleted immediately
             os.remove(self.parameter_file)
+                
+        return result
 
     def __repr__(self):
         return "Record #%s" % self.label
@@ -215,6 +254,12 @@ class Record(object):
         """
         self.datastore.delete(*self.output_data)
         self.output_data = []
+
+    def add_tag(self, tag):
+        if STATUS_PATTERN.match(tag):
+            # remove any existing status tags
+            self.tags = set((t for t in self.tags if not STATUS_PATTERN.match(t)))
+        self.tags.add(tag)
 
     @property
     def command_line(self):

--- a/sumatra/recordstore/django_store/models.py
+++ b/sumatra/recordstore/django_store/models.py
@@ -70,6 +70,10 @@ class Project(BaseModel):
     id = models.SlugField(primary_key=True)
     name = models.CharField(max_length=200)
     description = models.TextField(blank=True)
+    columns = ["Label", "Date/Time", "Reason", "Outcome", 
+               "Input data", "Output data", "Duration", "Processes", 
+               "Executable", "Main", "Version", "Arguments", "Tags"]
+
 
     class Meta(object):
         ordering = ('id',)

--- a/sumatra/web/templates/record_detail.html
+++ b/sumatra/web/templates/record_detail.html
@@ -45,7 +45,7 @@
                 {% if not read_only %}
                 <button type="button" class="btn btn-xs pull-right" data-toggle="modal" data-target="#editTagsModal"><span class="glyphicon glyphicon-pencil"></span> Edit</button>
                 {% endif %}
-                {% for tag in record.tag_objects %}<span class="label label-default">{{tag.name}}</span> {% endfor %}</dd>
+                {% for tag in record.tag_objects %}{{tag.name|labelize_tag}} {% endfor %}</dd>
         </dl>
         {% if not read_only and not record.outcome %}
         <p><button type="button" class="btn btn-xs btn-success pull-right" data-toggle="modal" data-target="#editOutcomeModal"><span class="glyphicon glyphicon-plus"></span> Add outcome</button></p>
@@ -383,6 +383,35 @@
   </div> <!-- modal-dialog -->
 </div> <!-- modal -->
 
+<div class="modal fade" id="editStatusModal">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+        <h4 class="modal-title">Status</h4>
+      </div>
+      <div class="modal-body">
+        <div class="form-group">
+          <select id="status">
+            {% with "initialized pre_run running finished failed killed succeeded crashed" as statuses %}
+              {% for status in statuses.split %}
+                <option value={{status}} 
+                {% if status == record.status %}selected="selected"{% endif %}>
+                  {{status|title}}
+                </option>
+              {% endfor %}  
+            {% endwith %}
+          </select>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" id="saveStatus">Save</button>
+      </div>
+    </div> <!-- modal-content -->
+  </div> <!-- modal-dialog -->
+</div> <!-- modal -->
+
 <div class="modal fade" id="deleteModal">
   <div class="modal-dialog">
     <div class="modal-content">
@@ -461,6 +490,22 @@ $(document).ready(function() {
             type: 'POST',
             url: '.',
             data: {'tags': $('#tag_list').val()},
+            success: function() {
+                success = true;
+            },
+            async: false
+        });
+        if (success) {
+            window.open('.','_self');
+        };
+    });
+
+    /* Save status */
+    $('#saveStatus').click(function() {
+        $.ajax({
+            type: 'POST',
+            url: '.',
+            data: {'status': $('#status').val()},
             success: function() {
                 success = true;
             },

--- a/sumatra/web/templates/record_list.html
+++ b/sumatra/web/templates/record_list.html
@@ -54,19 +54,9 @@
 <!-- <table id="records" class="display" cellspacing="0" width="100%"> -->
     <thead>
     <tr>
-        <th>Label</th>
-        <th>Date/Time</th>
-        <th>Reason</th>
-        <th>Outcome</th>
-        <th>Input&nbsp;data</th>
-        <th>Output&nbsp;data</th>
-        <th>Duration</th>
-        <th>Processes</th>
-        <th>Executable</th>
-        <th>Main</th>
-        <th>Version</th>
-        <th>Arguments</th>
-        <th>Tags</th>
+        {% for column in project.columns %}
+          <th>{{column|nbsp}}</th>
+        {% endfor %}
     </tr>
     </thead>
 
@@ -101,7 +91,7 @@
         <td><a target="script_content" onclick="window.open('/{{project.id}}/{{record.label}}/script','script_content','width=640,height=600,scrollbars=yes,resizable=yes')"><span class="glyphicon glyphicon-file"></span></a> {{record.main_file|ubreak}}</td>
         <td>{{record.version|cut:"vers"|truncatechars:10}}{% if record.diff %}*{% endif %}</td>
         <td>{{record.script_arguments}}</td>
-        <td>{{record.tags}}</td>
+        <td>{% for tag in record.tag_objects %}{{tag.name|labelize_tag}}{% if not forloop.last %} {% endif %}{% endfor %}</td>
     </tr>
     {% endfor %}
     <tbody>
@@ -152,18 +142,10 @@
       </div>
       <div class="modal-body" id="columnsToDisplay">
         <h5>Columns to display</h5>
-        <div class="checkbox"><label><input type="checkbox" data-column='1' checked="checked"> Date/Time</label></div>
-        <div class="checkbox"><label><input type="checkbox" data-column='2' checked="checked"> Reason</label></div>
-        <div class="checkbox"><label><input type="checkbox" data-column='3' checked="checked"> Outcome</label></div>
-        <div class="checkbox"><label><input type="checkbox" data-column='4' checked="checked"> Input data</label></div>
-        <div class="checkbox"><label><input type="checkbox" data-column='5' checked="checked"> Output data</label></div>
-        <div class="checkbox"><label><input type="checkbox" data-column='6' checked="checked"> Duration</label></div>
-        <div class="checkbox"><label><input type="checkbox" data-column='7' checked="checked"> Processes</label></div>
-        <div class="checkbox"><label><input type="checkbox" data-column='8' checked="checked"> Executable</label></div>
-        <div class="checkbox"><label><input type="checkbox" data-column='9' checked="checked"> Main</label></div>
-        <div class="checkbox"><label><input type="checkbox" data-column='10' checked="checked"> Version</label></div>
-        <div class="checkbox"><label><input type="checkbox" data-column='11' checked="checked"> Arguments</label></div>
-        <div class="checkbox"><label><input type="checkbox" data-column='12' checked="checked"> Tags</label></div>
+        {% for column in project.columns|slice:"1:" %}
+          <div class="checkbox"><label><input type="checkbox" 
+          data-column='{{forloop.counter}}' checked="checked">{{column}}</label></div>
+        {% endfor %}
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>

--- a/sumatra/web/templatetags/filters.py
+++ b/sumatra/web/templatetags/filters.py
@@ -9,12 +9,14 @@ import os
 from django import template
 from django.template.defaultfilters import stringfilter
 from django.conf import settings
+from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 try:
     from django.utils.encoding import force_bytes, force_text  # Django 1.5+
 except ImportError:
     from django.utils.encoding import smart_str as force_bytes, force_unicode as force_text  # Django 1.4
 from sumatra.formatting import human_readable_duration
+from sumatra.core import STATUS_PATTERN
 
 register = template.Library()
 
@@ -25,7 +27,12 @@ def ubreak(text):
     text_out = text.replace("_", "_<wbr>").replace("/", "/<wbr>")
     return mark_safe(text_out)
 
-
+@register.filter
+@stringfilter
+def nbsp(text):
+    text_out = text.replace(" ", "&nbsp;")
+    return mark_safe(text_out)
+    
 @register.filter
 @stringfilter
 def basename(text):
@@ -72,3 +79,28 @@ def restructuredtext(value):
         docutils_settings = getattr(settings, "RESTRUCTUREDTEXT_FILTER_SETTINGS", {})
         parts = publish_parts(source=force_bytes(value), writer_name="html4css1", settings_overrides=docutils_settings)
         return mark_safe(force_text(parts["fragment"]))
+        
+@register.filter(needs_autoescape=True)
+def labelize_tag(tag, autoescape=True):
+    if autoescape:
+        esc = conditional_escape
+    else:
+        esc = lambda x: x
+    style_map = {
+        'initialized': "default",
+        'pre_run': "info",
+        'running': "info",
+        'finished': "primary",
+        'failed': "danger",
+        'killed': "warning",
+        'succeeded': "success",
+        'crashed': "danger"
+    }
+    m = STATUS_PATTERN.match(tag)
+    if m:
+        style = style_map[m.group(2)]
+#         tag = m.group(1)
+    else:
+        style = "default"
+    result = '<span class="label label-%s">%s</span>' % (style, esc(tag))
+    return mark_safe(result)

--- a/test/unittests/test_commands.py
+++ b/test/unittests/test_commands.py
@@ -82,6 +82,7 @@ class MockRecord(object):
     main_file = "main.py"
     version = "42"
     launch_mode = "dummy"
+    tags = ["_finished_"]
     def __init__(self, label):
         self.label = label
 
@@ -661,6 +662,13 @@ class TestTagCommand(unittest.TestCase):
     def test_single_arg_interpreted_as_tag_on_last_record(self):
         commands.tag(["foo"])
         self.assertEqual(self.prj.tags["most_recent"], "foo")
+
+    def test_with_unknown_status(self):
+        self.assertRaises(ValueError, commands.tag, ["_cromulent_"])
+
+    def test_single_arg_interpreted_as_status_on_last_record(self):
+        commands.tag(["_succeeded_"])
+        self.assertEqual(self.prj.tags["most_recent"], "_succeeded_")
 
     def test_tag_multiple_records(self):
         commands.tag(["foo", "a", "b", "c"])

--- a/test/unittests/test_launch.py
+++ b/test/unittests/test_launch.py
@@ -42,11 +42,11 @@ class BaseTestLaunchMode(object):
         with open("test_parameters", "w") as f:
             f.write("b = 3\n")
 
-    def test__run__should_return_True_if_the_command_completed_successfully(self):
+    def test__run__should_return_zero_if_the_command_completed_successfully(self):
         self.write_valid_script()
         self.write_parameter_file()
         prog = MockExecutable(sys.executable)
-        self.assertEqual(True, self.lm.run(prog, "valid_test_script.py", "test_parameters"))
+        self.assertEqual(0, self.lm.run(prog, "valid_test_script.py", "test_parameters"))
 
     def test__run__should_raise_an_Exception_if_the_executable_does_not_exist(self):
         self.write_valid_script()
@@ -64,11 +64,11 @@ class BaseTestLaunchMode(object):
         self.write_valid_script()
         self.lm.run(prog, "valid_test_script.py", None)
 
-    def test__run__should_return_False_if_the_command_failed(self):
+    def test__run__should_return_one_if_the_command_failed(self):
         self.write_invalid_script()
         self.write_parameter_file()
         prog = MockExecutable(sys.executable)
-        self.assertEqual(False, self.lm.run(prog, "invalid_test_script.py", "test_parameters"))
+        self.assertEqual(1, self.lm.run(prog, "invalid_test_script.py", "test_parameters"))
 
     def test__str(self):
         # just to make sure no errors are returned

--- a/test/unittests/test_projects.py
+++ b/test/unittests/test_projects.py
@@ -151,6 +151,9 @@ class MockRecord(object):
     def difference(r1, r2, igm, igf):
         return ""
 
+    def add_tag(self, tag):
+        self.tags.add(tag)
+
 
 class MockDatastore(object):
 

--- a/test/unittests/test_records.py
+++ b/test/unittests/test_records.py
@@ -34,7 +34,7 @@ class MockLaunchMode(object):
     def pre_run(self, executable):
         pass
     def run(self, *args, **kwargs):
-        pass
+        return 0
 
 class MockFile(object):
     def __init__(self, name):


### PR DESCRIPTION
It's probably a reflection on my skills as a programmer, but most of my jobs either crash or freeze. As a result, sumatra doesn't record a lot of the things I'd like to know later (I only saw the [Real-Time Update of Record](https://groups.google.com/forum/#!topic/sumatra-users/o6J52Kk-wh8) thread after I wrote this). 

This pull request causes the record to be saved at intermediate points, tags the status, and records the resultcode in the event of an error, and colors the status tags in the web view. I've tested with sqlite, postgresql, and shelve. I can't get sumatra server to work in order to test that.

I [originally tackled this](https://github.com/guyer/sumatra/tree/record_status-as_column) by adding a new `status` property to the `Record` objects. This forced an upgrade to the database, lots of tinkering with the formatting and web templates, a new subcommand, and it wasn't possible to filter results based on status without a lot more code. Recording the status as a tag avoids all that at the cost of a somewhat more complex process for setting tags. As such, I think tags are a better approach.
