### PR TITLE
retrieving datastore implementations from registry in smtweb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib nose pillow
+  - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION numpy scipy libgfortran matplotlib nose pillow
   - source activate testenv
   - pip install -r ci/requirements.txt
   - pip install -r ci/requirements-test.txt

--- a/sumatra/recordstore/django_store/models.py
+++ b/sumatra/recordstore/django_store/models.py
@@ -12,15 +12,16 @@ from builtins import object
 import json
 from django.db import models
 from sumatra import programs, launch, datastore, records, versioncontrol, parameters, dependency_finder
+from sumatra.datastore import get_data_store
+import datetime
+import django
+from distutils.version import LooseVersion
+from sumatra.core import get_registered_components
 import warnings
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     import tagging.fields
     from tagging.models import Tag
-import datetime
-import django
-from distutils.version import LooseVersion
-from sumatra.core import get_registered_components
 
 
 class SumatraObjectsManager(models.Manager):
@@ -181,9 +182,9 @@ class Datastore(BaseModel):
 
     def to_sumatra(self):
         parameters = eval(self.parameters)
-        if hasattr(datastore, self.type):
-            ds = getattr(datastore, self.type)(**parameters)
-        else:
+        try:
+            ds = get_data_store(self.type, parameters)
+        except KeyError:
             raise Exception("Unknown datastore type '%s' stored in database" % self.type)
         return ds
 


### PR DESCRIPTION
This allows to use arbitrary datastore -- basically all datastores
that are registered in the registry.