### PR TITLE
delete data subfolder

### DIFF
--- a/sumatra/datastore/filesystem.py
+++ b/sumatra/datastore/filesystem.py
@@ -152,6 +152,8 @@ class FileSystemDataStore(DataStore):
                 warnings.warn("Tried to delete %s, but it did not exist." % key)
             else:
                 os.remove(data_item.full_path)
+                if len(os.listdir(self.root)) == 0:
+                    os.rmdir(self.root)
 
     def contains_path(self, path):
         return os.path.isfile(os.path.join(self.root, path))


### PR DESCRIPTION
The concept of this PR is to enable user to delete the subfolder of Data, e.g. 
`ls <sumatra_project>/Data/5c0a3870c658/<output_data>`,
 if sumatra stores outputdata in subfolder of Data. 
This happens when sumatra appends cmdline (maybe also parameter) to label. 

Why I use it? I regularly run sumatra with parallel computing on cluster (use msub) and tracking of output data is not correct without subfolders. You can configure sumatra with
`smt configure -l cmdline`

And it will be nice to delete the corresponding subfolder for the deleting records.