### PR TITLE
small fix on document about VCS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ or::
 
     $ easy_install sumatra
 
-You will also need to install Python bindings for the version control system(s) you use, e.g.:
+You will also need to install Python bindings for the version control system(s) you use, e.g.::
 
     $ pip install gitpython
     $ pip install mercurial hgapi


### PR DESCRIPTION
Just added `:` for rst document so it would be rendered as code.