### PR TITLE
Fix unclosed html tag in the project list template

### DIFF
--- a/sumatra/web/templates/project_list.html
+++ b/sumatra/web/templates/project_list.html
@@ -13,5 +13,6 @@
         <hr>
         {{project.description|restructuredtext}}&nbsp;
         {% endif %}
+    </div>
     {% endfor %}
 {% endblock %}


### PR DESCRIPTION
This PR closes a html tag in the projet list template.