### PR TITLE
Fix configparser dependency in Py2

### DIFF
--- a/ci/requirements-2.6.txt
+++ b/ci/requirements-2.6.txt
@@ -5,5 +5,6 @@ ordereddict
 unittest2
 importlib
 pathlib
+configparser
 # optional, if you use Bazaar
 bzr

--- a/ci/requirements-2.7.txt
+++ b/ci/requirements-2.7.txt
@@ -1,4 +1,5 @@
 # additional requirements for Python 2.7
 pathlib
+configparser
 # optional, if you use Bazaar
 bzr

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ install_requires = ['Django>=1.6, <1.9', 'django-tagging', 'httplib2',
 major_python_version, minor_python_version, _, _, _ = sys.version_info
 if major_python_version < 3 or (major_python_version == 3 and minor_python_version < 4):
     install_requires.append('pathlib')
+    install_requires.append('configparser')
 
 setup(
     name = "Sumatra",

--- a/tox.ini
+++ b/tox.ini
@@ -18,11 +18,13 @@ deps =
     {[testenv]deps}
     unittest2
     pathlib
+    configparser
 
 [testenv:py27]
 deps =
     {[testenv]deps}
     pathlib
+    configparser
 
 [testenv:py33]
 deps =


### PR DESCRIPTION
python-future removed its alias for `Configparser` in Python2 starting
from version 0.16 released 2016-10-27 in favor of an explicitly
backported version of `configparser`. Through that `import configparser`
breaks now. A Py2 install of Sumatra will now need the backport as a
dependency.

Fixes #352.