### PR TITLE
Make the NTParameter.save method compatible with NeuroTools' ParameterSet

### DIFF
--- a/sumatra/dependency_finder/python.py
+++ b/sumatra/dependency_finder/python.py
@@ -195,6 +195,8 @@ def find_imported_packages(filename, executable_path, debug=0, exclude_stdlib=Tr
     # could run in parallel with the simulation (good for multicore): we could
     # move setting of dependencies to after the simulation, rather than having it
     # in record.register()
+
+    # HACK Added excludes=['jinja2.asyncsupport']
     script = textwrap.dedent("""
         from modulefinder import ModuleFinder
         import sys, os
@@ -204,7 +206,7 @@ def find_imported_packages(filename, executable_path, debug=0, exclude_stdlib=Tr
                         os.path.join(stdlib_path, "plat-mac"),
                         os.path.join(stdlib_path, "plat-mac", "lib-scriptpackages"))
         exclude_stdlib = %s
-        finder = ModuleFinder(path=sys.path, debug=%d)
+        finder = ModuleFinder(path=sys.path, debug=%d, excludes=['jinja2.asyncsupport'])
         try:
             finder.run_script("%s")
         except Exception as ex:

--- a/sumatra/parameters.py
+++ b/sumatra/parameters.py
@@ -216,6 +216,12 @@ class NTParameterSet(parameters.ParameterSet, ParameterSet):
     # just a re-name, to clarify things
     name = ".ntparameterset"
 
+    def save(self, filename, add_extension=False):
+        if add_extension:
+            filename += ".params"
+        super().save(filename)
+        return filename
+
 
 @component
 class SimpleParameterSet(ParameterSet):


### PR DESCRIPTION
NeuroTools' ParameterSet class does not provide an 'add_extension', as the other
parameter types defined in Sumatra do. This leads to problems as other functions
pass that keyword explicitly.
This commit adds a save method to the empty NTParameter class, which catches the
call and treats the 'add_extension' keyword, before forwarding the call to
the parameter's save method as before.