### PR TITLE
Add an option "--ignore-parameters" to turn off any attempt to parse command-line files as parameter files

### DIFF
--- a/sumatra/commands.py
+++ b/sumatra/commands.py
@@ -81,7 +81,7 @@ def parse_executable_str(exec_str):
     return exec_str[:first_space], exec_str[first_space:]
 
 def parse_arguments(args, input_datastore, stdin=None, stdout=None,
-                    allow_command_line_parameters=True):
+                    allow_command_line_parameters=True, ignore_parameters=False):
     cmdline_parameters = []
     script_args = []
     parameter_sets = []
@@ -89,7 +89,10 @@ def parse_arguments(args, input_datastore, stdin=None, stdout=None,
     for arg in args:
         have_parameters = False
         if os.path.isfile(arg):  # could be a parameter file or a data file
-            parameters = build_parameters(arg)
+            if ignore_parameters:
+                parameters = None
+            else:
+                parameters = build_parameters(arg)
             if parameters is not None:
                 parameter_sets.append(parameters)
                 script_args.append("<parameters>")
@@ -103,7 +106,7 @@ def parse_arguments(args, input_datastore, stdin=None, stdout=None,
                 data_key = input_datastore.generate_keys(path)
                 input_data.extend(data_key)
                 script_args.append(arg)
-            elif allow_command_line_parameters and "=" in arg:  # cmdline parameter
+            elif allow_command_line_parameters and not ignore_parameters and "=" in arg:  # cmdline parameter
                 cmdline_parameters.append(arg)
             else:  # a flag or something, passed on unchanged
                 script_args.append(arg)
@@ -127,7 +130,7 @@ def parse_arguments(args, input_datastore, stdin=None, stdout=None,
                     message, name, value = v.args
                     warnings.warn(message)
                     warnings.warn("'{0}={1}' not defined in the parameter file".format(name, value))
-                    ps.update({name: value}) ## for now, add the command line param anyway
+                    ps.update({name: value})  # add the command line param anyway
         else:
             raise Exception("Command-line parameters supplied but without a parameter file to put them into.")
             # ought really to have a more specific Exception and to catch it so as to give a helpful error message to user
@@ -251,6 +254,8 @@ def configure(argv):
     parser.add_argument('-o', '--launch_mode_options', help="extra options for the given launch mode, to be given in quotes with a leading space, e.g. ' --foo=3'")
     parser.add_argument('-p', '--plain', dest='plain', action='store_true', help="pass arguments to the 'run' command straight through to the program. Otherwise arguments of the form name=value can be used to overwrite default parameter values.")
     parser.add_argument('--no-plain', dest='plain', action='store_false', help="arguments to the 'run' command of the form name=value will overwrite default parameter values. This is the opposite of the --plain option.")
+    parser.add_argument('--ignore-parameters', dest='ignore_parameters', action='store_true', help="do not attempt to parse any parameter files.")
+    parser.add_argument('--parse-parameters', dest='ignore_parameters', action='store_false', help="parse parameter files if found. This is the default.")
     parser.add_argument('-s', '--store', help="Change the record store to the specified path, URL or URI (must be specified). {0}".format(store_arg_help))
 
     datastore = parser.add_mutually_exclusive_group()
@@ -321,6 +326,9 @@ def configure(argv):
         project.default_launch_mode.options = args.launch_mode_options.strip()
     if args.plain is not None:
         project.allow_command_line_parameters = not args.plain
+    if args.ignore_parameters is not None:
+        project.ignore_parameters = args.ignore_parameters
+        print("Setting ignore parameters to {}".format(args.ignore_parameters))
     if args.add_plugin:
         project.load_plugins(args.add_plugin)
     if args.remove_plugin:
@@ -385,7 +393,8 @@ def run(argv):
                                                           project.input_datastore,
                                                           args.stdin,
                                                           args.stdout,
-                                                          project.allow_command_line_parameters)
+                                                          project.allow_command_line_parameters,
+                                                          project.ignore_parameters)
     if len(parameters) == 0:
         parameters = {}
     elif len(parameters) == 1:

--- a/sumatra/parameters.py
+++ b/sumatra/parameters.py
@@ -70,7 +70,7 @@ class ParameterSet(with_metaclass(abc.ABCMeta, object)):
 
     def _new_param_check(self, name, value):
         try:
-            self.values[name]
+            self._values[name]
         except KeyError:
             raise ValueError("")
 
@@ -107,6 +107,9 @@ class ParameterSet(with_metaclass(abc.ABCMeta, object)):
 
     def diff(self, other):
         return _dict_diff(self, other)
+
+    def items(self):
+        return self._values
 
 
 def _dict_diff(a, b):
@@ -149,16 +152,16 @@ class YAMLParameterSet(ParameterSet):
             try:
                 if os.path.exists(initialiser):
                     with open(initialiser) as fid:
-                        self.values = yaml.load(fid)
+                        self._values = yaml.load(fid)
                     self.source_file = initialiser
                 else:
                     if initialiser:
-                        self.values = yaml.load(initialiser)
+                        self._values = yaml.load(initialiser)
                     else:
-                        self.values = {}
+                        self._values = {}
             except yaml.YAMLError:
                 raise SyntaxError("Misformatted YAML file")
-            if not isinstance(self.values, dict):
+            if not isinstance(self._values, dict):
                 raise SyntaxError("YAML file cannot be represented as a dict")
         else:
             raise ImportError("Cannot import PyYAML module")
@@ -167,7 +170,7 @@ class YAMLParameterSet(ParameterSet):
         return self.pretty()
 
     def __getitem__(self, name):
-        return self.values[name]
+        return self._values[name]
 
     def __eq__(self, other):
         return self.as_dict() == other.as_dict()
@@ -176,7 +179,7 @@ class YAMLParameterSet(ParameterSet):
         return not self.__eq__(other)
 
     def keys(self):
-        return self.values.keys()
+        return self._values.keys()
 
     def pretty(self, expand_urls=False):
         """
@@ -187,26 +190,26 @@ class YAMLParameterSet(ParameterSet):
                     not used.
         """
 
-        output = yaml.dump(self.values, indent=4)
+        output = yaml.dump(self._values, indent=4)
         return output
 
     def as_dict(self):
-        return self.values
+        return self._values
 
     def save(self, filename, add_extension=False):
         if add_extension:
             filename += ".yaml"
         with open(filename, "w") as f:
-            yaml.dump(self.values, f)
+            yaml.dump(self._values, f)
         return filename
 
     def update(self, E, **F):
-        self.values.update(E, **F)
+        self._values.update(E, **F)
     update.__doc__ = dict.update.__doc__
 
     def pop(self, key, d=None):
-        if key in self.values:
-            return self.values.pop(key)
+        if key in self._values:
+            return self._values.pop(key)
         else:
             return d
 
@@ -219,8 +222,12 @@ class NTParameterSet(parameters.ParameterSet, ParameterSet):
     def save(self, filename, add_extension=False):
         if add_extension:
             filename += ".params"
-        super().save(filename)
+        super(NTParameterSet, self).save(filename)
         return filename
+
+    def _new_param_check(self, name, value):
+        if name not in self:
+            raise ValueError("")
 
 
 @component
@@ -238,7 +245,7 @@ class SimpleParameterSet(ParameterSet):
         Create a new parameter set from a file or string. In both cases,
         parameters should be separated by newlines.
         """
-        self.values = {}
+        self._values = {}
         self.types = {}
         self.comments = {}
         if isinstance(initialiser, dict):
@@ -308,7 +315,7 @@ class SimpleParameterSet(ParameterSet):
         if value is not None and not isinstance(value, (int, float, str, bool, list, tuple)):
             raise TypeError("Value must be one of the basic types (a numeric value, bool, "
                 "string, list, tuple or None. Got: '{}' ({})".format(value, type(value)))
-        self.values[name] = value
+        self._values[name] = value
         self.types[name] = type(value)
         if comment is not None:
             self.comments[name] = comment
@@ -317,20 +324,20 @@ class SimpleParameterSet(ParameterSet):
         return self.pretty()
 
     def __getitem__(self, name):
-        return self.values[name]
+        return self._values[name]
 
     def __eq__(self, other):
-        return ((self.values == other.values) and (self.types == other.types))
+        return ((self._values == other._values) and (self.types == other.types))
 
     def __ne__(self, other):
         return not self.__eq__(other)
 
     def keys(self):
-        return self.values.keys()
+        return self._values.keys()
 
     def pop(self, k, d=POP_NONE):
-        if k in self.values:
-            v = self.values.pop(k)
+        if k in self._values:
+            v = self._values.pop(k)
             self.types.pop(k)
             self.comments.pop(k, None)
             return v
@@ -348,7 +355,7 @@ class SimpleParameterSet(ParameterSet):
                     not used.
         """
         output = []
-        for name, value in self.values.items():
+        for name, value in self._values.items():
             if isinstance(value, str):
                 output.append('%s = "%s"' % (name, value))
             else:
@@ -358,7 +365,7 @@ class SimpleParameterSet(ParameterSet):
         return "\n".join(output)
 
     def as_dict(self):
-        return self.values.copy()
+        return self._values.copy()
 
     def save(self, filename, add_extension=False):
         if add_extension:
@@ -521,13 +528,13 @@ class JSONParameterSet(ParameterSet):
         try:
             if os.path.exists(initialiser):
                 with open(initialiser) as fid:
-                    self.values = json.load(fid)
+                    self._values = json.load(fid)
                 self.source_file = initialiser
             else:
                 if initialiser:
-                    self.values = json.loads(initialiser)
+                    self._values = json.loads(initialiser)
                 else:
-                    self.values = {}
+                    self._values = {}
         except ValueError:
             raise SyntaxError("Misformatted JSON file")
 
@@ -535,7 +542,7 @@ class JSONParameterSet(ParameterSet):
         return self.pretty()
 
     def __getitem__(self, name):
-        return self.values[name]
+        return self._values[name]
 
     def __eq__(self, other):
         return self.as_dict() == other.as_dict()
@@ -544,7 +551,7 @@ class JSONParameterSet(ParameterSet):
         return not self.__eq__(other)
 
     def keys(self):
-        return self.values.keys()
+        return self._values.keys()
 
     def pretty(self, expand_urls=False):
         """
@@ -555,26 +562,26 @@ class JSONParameterSet(ParameterSet):
                     not used.
         """
 
-        output = json.dumps(self.values, sort_keys=True, indent=4)
+        output = json.dumps(self._values, sort_keys=True, indent=4)
         return output
 
     def as_dict(self):
-        return self.values
+        return self._values
 
     def save(self, filename, add_extension=False):
         if add_extension:
             filename += ".json"
         with open(filename, "w") as f:
-            json.dump(self.values, f)
+            json.dump(self._values, f)
         return filename
 
     def update(self, E, **F):
-        self.values.update(E, **F)
+        self._values.update(E, **F)
     update.__doc__ = dict.update.__doc__
 
     def pop(self, key, d=None):
-        if key in self.values:
-            return self.values.pop(key)
+        if key in self._values:
+            return self._values.pop(key)
         else:
             return d
 

--- a/sumatra/projects.py
+++ b/sumatra/projects.py
@@ -79,7 +79,8 @@ class Project(object):
                  on_changed='error', description='', data_label=None,
                  input_datastore=None, label_generator='timestamp',
                  timestamp_format=TIMESTAMP_FORMAT,
-                 allow_command_line_parameters=True, plugins=[]):
+                 allow_command_line_parameters=True,
+                 ignore_parameters=False, plugins=[]):
         self.path = os.getcwd()
         if not os.path.exists(".smt"):
             os.mkdir(".smt")
@@ -107,6 +108,7 @@ class Project(object):
         self.timestamp_format = timestamp_format
         self.sumatra_version = sumatra.__version__
         self.allow_command_line_parameters = allow_command_line_parameters
+        self.ignore_parameters = ignore_parameters
         self._most_recent = None
         self.plugins = []
         self.load_plugins(*plugins)
@@ -129,7 +131,8 @@ class Project(object):
                      'default_main_file', 'on_changed', 'description',
                      'data_label', '_most_recent', 'input_datastore',
                      'label_generator', 'timestamp_format', 'sumatra_version',
-                     'allow_command_line_parameters', 'plugins'):
+                     'allow_command_line_parameters', 'ignore_parameters',
+                     'plugins'):
             try:
                 attr = getattr(self, name)
             except:

--- a/test/unittests/test_commands.py
+++ b/test/unittests/test_commands.py
@@ -115,6 +115,7 @@ class MockProject(object):
     on_changed = "sound the alarm"
     data_label = "pluck from the ether"
     allow_command_line_parameters = True
+    ignore_parameters = False
     record_store = MockRecordStore("default")
     saved = False
     info_called = False

--- a/test/unittests/test_parameters.py
+++ b/test/unittests/test_parameters.py
@@ -89,7 +89,7 @@ class TestSimpleParameterSet(unittest.TestCase):
 
     def test__init__should_accept_an_empty_initializer(self):
         P = SimpleParameterSet("")
-        self.assertEqual(P.values, {})
+        self.assertEqual(P._values, {})
 
     def test__init__should_accept_dict(self):
         P = SimpleParameterSet({'x': 2, 'y': 3})
@@ -102,7 +102,7 @@ class TestSimpleParameterSet(unittest.TestCase):
         with open("test_file", "w") as f:
             f.write(init)
         P2 = SimpleParameterSet("test_file")
-        self.assertEqual(P1.values, P2.values)
+        self.assertEqual(P1.items(), P2.items())
         os.remove("test_file")
 
     def test__init__should_raise_a_TypeError_if_initializer_is_not_a_filename_or_string(self):
@@ -170,7 +170,7 @@ class TestSimpleParameterSet(unittest.TestCase):
         init = "x = 2\ny = 3\nz = 'hello'"
         P1 = SimpleParameterSet(init)
         P2 = SimpleParameterSet(P1.pretty())
-        self.assertEqual(P1.values, P2.values)
+        self.assertEqual(P1.items(), P2.items())
 
     def test__save__should_backup_an_existing_file_before_overwriting_it(self):
         # not really sure what the desired behaviour is here


### PR DESCRIPTION
See #300 

This PR depends on #372 and should be merged after that one.