### PR TITLE
Make CI run through without errors again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION numpy scipy libgfortran matplotlib nose pillow
+  - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION numpy scipy libgfortran-ng matplotlib nose pillow
   - source activate testenv
   - pip install -r ci/requirements.txt
   - pip install -r ci/requirements-test.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 sudo: required
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 env:
   global:
     - PATH=/home/travis/miniconda/bin:$PATH

--- a/ci/requirements-3.7.txt
+++ b/ci/requirements-3.7.txt
@@ -1,0 +1,2 @@
+# Additional requirements for Python 3.5
+pyyaml  # this is already in requirements.txt, but pip doesn't allow empty requirements files

--- a/test/system/test_ircr.py
+++ b/test/system/test_ircr.py
@@ -22,6 +22,7 @@ from utils import (setup, teardown, run_test, build_command, assert_file_exists,
                    assert_config, assert_label_equal, assert_records, assert_return_code,
                    edit_parameters, expected_short_list, substitute_labels)
 from functools import partial
+import re
 
 repository = "https://bitbucket.org/apdavison/ircr2013"
 #repository = "/Volumes/USERS/andrew/dev/ircr2013"  # during development
@@ -48,7 +49,7 @@ test_steps = [
      assert_in_output, "updating to branch default"),
     ("Run the computation without Sumatra",
      "python glass_sem_analysis.py default_parameters MV_HFV_012.jpg",
-     assert_in_output, "2416.86315789 60.0",
+     assert_in_output, re.compile(r"2416\.863[0-9]* 60\.0"),
      assert_file_exists, os.path.join("Data", datetime.now().strftime("%Y%m%d")),  # Data subdirectory contains another subdirectory labelled with today's date)
      ),  # assert(subdirectory contains three image files).
     ("Set up a Sumatra project",
@@ -56,7 +57,7 @@ test_steps = [
      assert_in_output, "Sumatra project successfully set up"),
     ("Run the ``glass_sem_analysis.py`` script with Sumatra",
      "smt run -e python -m glass_sem_analysis.py -r 'initial run' default_parameters MV_HFV_012.jpg",
-     assert_in_output, ("2416.86315789 60.0", "histogram.png")),
+     assert_in_output, (re.compile(r"2416\.863[0-9]* 60\.0"), "histogram.png")),
     ("Comment on the outcome",
      "smt comment 'works fine'"),
     ("Set defaults",

--- a/test/system/utils.py
+++ b/test/system/utils.py
@@ -23,7 +23,7 @@ label_pattern = re.compile("Record label for this run: '(?P<label>\d{8}-\d{6})'"
 label_pattern = re.compile("Record label for this run: '(?P<label>[\w\-_]+)'")
 
 info_pattern = r"""Project name        : (?P<project_name>\w+)
-Default executable  : (?P<executable>\w+) \(version: \d+.\d+.\d+\) at /[\w\/_-]+/bin/python
+Default executable  : (?P<executable>\w+) \(version: \d+.\d+.\d+\) at /[\w\/_.-]+/bin/python
 Default repository  : MercurialRepository at \S+/sumatra_exercise \(upstream: \S+/ircr2013\)
 Default main file   : (?P<main>\w+.\w+)
 Default launch mode : serial

--- a/test/system/utils.py
+++ b/test/system/utils.py
@@ -83,10 +83,10 @@ def get_label(p):
 
 def assert_in_output(p, texts):
     """Assert that the stdout from process 'p' contains all of the provided text."""
-    if isinstance(texts, (str, re.Pattern)):
+    if isinstance(texts, (str, type(re.compile("")))):
         texts = [texts]
     for text in texts:
-        if isinstance(text, re.Pattern):
+        if isinstance(text, type(re.compile(""))):
             assert text.search(p.stdout.text), "regular expression '{0}' has no match in '{1}'".format(text, p.stdout.text)
         else:
             assert text in p.stdout.text, "'{0}' is not in '{1}'".format(text, p.stdout.text)

--- a/test/system/utils.py
+++ b/test/system/utils.py
@@ -83,10 +83,13 @@ def get_label(p):
 
 def assert_in_output(p, texts):
     """Assert that the stdout from process 'p' contains all of the provided text."""
-    if isinstance(texts, str):
+    if isinstance(texts, (str, re.Pattern)):
         texts = [texts]
     for text in texts:
-        assert text in p.stdout.text, "'{0}' is not in '{1}'".format(text, p.stdout.text)
+        if isinstance(text, re.Pattern):
+            assert text.search(p.stdout.text), "regular expression '{0}' has no match in '{1}'".format(text, p.stdout.text)
+        else:
+            assert text in p.stdout.text, "'{0}' is not in '{1}'".format(text, p.stdout.text)
 
 
 def assert_config(p, expected_config):


### PR DESCRIPTION
Self-explanatory, let me know if you want me to squash the commits or if it's fine the way it is.

This also deprecates Python 3.4 in CI and introduces 3.7 on the other end.