### PR TITLE
Add support for MySQL and MariaDB

### DIFF
--- a/test/system/fixtures/Dockerfile.mysql
+++ b/test/system/fixtures/Dockerfile.mysql
@@ -16,5 +16,5 @@ RUN service mysql start &&\
 	mysql -u root --password=${MYSQL_PWD} -e "GRANT ALL PRIVILEGES ON sumatra_test.* TO docker IDENTIFIED BY 'docker';"
 
 EXPOSE 5432
-VOLUME	["VOLUME /var/lib/mysql"]
+VOLUME ["/var/lib/mysql"]
 CMD ["mysqld"]

--- a/test/system/fixtures/Dockerfile.mysql
+++ b/test/system/fixtures/Dockerfile.mysql
@@ -1,0 +1,20 @@
+FROM debian:jessie
+
+RUN apt-get update
+RUN apt-get -y -q install python-software-properties software-properties-common python-pip 
+ENV MYSQL_PWD Pwd123
+RUN echo "mysql-server mysql-server/root_password password $MYSQL_PWD" | debconf-set-selections
+RUN echo "mysql-server mysql-server/root_password_again password $MYSQL_PWD" | debconf-set-selections
+RUN apt-get -y install mysql-server
+
+ENV WORK=/mysqlwork
+WORKDIR ${WORK}
+
+RUN service mysql start &&\
+	mysql -u root --password=${MYSQL_PWD} -e "CREATE USER docker IDENTIFIED BY 'docker';" &&\
+	mysql -u root --password=${MYSQL_PWD} -e "CREATE DATABASE sumatra_test;" && \
+	mysql -u root --password=${MYSQL_PWD} -e "GRANT ALL PRIVILEGES ON sumatra_test.* TO docker IDENTIFIED BY 'docker';"
+
+EXPOSE 5432
+VOLUME	["VOLUME /var/lib/mysql"]
+CMD ["mysqld"]

--- a/test/system/test_mysql.py
+++ b/test/system/test_mysql.py
@@ -55,17 +55,12 @@ def start_pg_container():
     global ctr, dkr
     env = docker.utils.kwargs_from_env(assert_hostname=False)
     dkr = docker.Client(timeout=60, **env)
-    environment = {
-        "MYSQL_DATABASE": "sumatra_test",
-        "MYSQL_USER": "docker",
-        "MYSQL_PASSWORD": "docker"
-    }
 
     host_config = dkr.create_host_config(publish_all_ports=True)
     # docker run -rm -P -name ms_test mysql_test
     ctr = dkr.create_container(image, command=None, hostname=None, user=None,
                                detach=False, stdin_open=False, tty=False,
-                               ports=None, environment=environment, dns=None,
+                               ports=None, environment=None, dns=None,
                                volumes=None, volumes_from=None,
                                network_disabled=False, name=None,
                                entrypoint=None, cpu_shares=None,

--- a/test/system/test_mysql.py
+++ b/test/system/test_mysql.py
@@ -50,7 +50,7 @@ def start_pg_container():
 
     Requires the "mysql_test" image. If this does not yet exist, run
 
-        docker build -t postgresql_test - < fixtures/Dockerfile.mysql
+        docker build -t mysql_test - < fixtures/Dockerfile.mysql
     """
     global ctr, dkr
     env = docker.utils.kwargs_from_env(assert_hostname=False)

--- a/test/system/test_mysql.py
+++ b/test/system/test_mysql.py
@@ -1,0 +1,125 @@
+"""
+Tests using a MySQL-based record store.
+
+
+Usage:
+    nosetests -v test_mysql.py
+or:
+    python test_mysql.py
+"""
+from __future__ import print_function
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import input
+
+import os
+from urllib.parse import urlparse
+try:
+    import docker
+    if "DOCKER_HOST" in os.environ:
+        have_docker = True
+    else:
+        have_docker = False
+except ImportError:
+    have_docker = False
+from unittest import SkipTest
+import utils
+from utils import setup, teardown as default_teardown, run_test, build_command
+
+ctr = None
+dkr = None
+image = "mysql_test"
+
+
+def create_script():
+    with open(os.path.join(utils.working_dir, "main.py"), "w") as fp:
+        fp.write("print('Hello world!')\n")
+
+
+def get_url():
+    info = dkr.containers()[0]
+    assert info["Image"] == image
+    host = urlparse(dkr.base_url).hostname
+    return "{0}:{1}".format(host, info["Ports"][0]["PublicPort"])
+
+
+def start_pg_container():
+    """
+    Launch a Docker container running MySQL, return the URL.
+
+    Requires the "mysql_test" image. If this does not yet exist, run
+
+        docker build -t postgresql_test - < fixtures/Dockerfile.mysql
+    """
+    global ctr, dkr
+    env = docker.utils.kwargs_from_env(assert_hostname=False)
+    dkr = docker.Client(timeout=60, **env)
+    environment = {
+        "MYSQL_DATABASE": "sumatra_test",
+        "MYSQL_USER": "docker",
+        "MYSQL_PASSWORD": "docker"
+    }
+
+    host_config = dkr.create_host_config(publish_all_ports=True)
+    # docker run -rm -P -name ms_test mysql_test
+    ctr = dkr.create_container(image, command=None, hostname=None, user=None,
+                               detach=False, stdin_open=False, tty=False,
+                               ports=None, environment=environment, dns=None,
+                               volumes=None, volumes_from=None,
+                               network_disabled=False, name=None,
+                               entrypoint=None, cpu_shares=None,
+                               working_dir=None, host_config=host_config)
+    dkr.start(ctr)
+    utils.env["url"] = get_url()
+
+
+def teardown():
+    global ctr, dkr
+    default_teardown()
+    if dkr is not None:
+        dkr.stop(ctr)
+
+
+test_steps = [
+    create_script,
+    ("Create repository", "git init"),
+    ("Add main file", "git add main.py"),
+    ("Commit main file", "git commit -m 'initial'"),
+    start_pg_container,
+    ("Set up a Sumatra project",
+     build_command("smt init --store=mysql://docker:docker@{}/sumatra_test -m main.py -e python MyProject", "url")),
+    ("Show project configuration", "smt info"),  # TODO: add assert
+    ("Run a computation", "smt run")
+]
+
+
+# TODO: add test skips where docker not found
+
+
+def test_all():
+    """Test generator for Nose."""
+    if not have_docker:
+        raise SkipTest("Tests require docker")
+    for step in test_steps:
+        if callable(step):
+            step()
+        else:
+            run_test.description = step[0]
+            yield tuple([run_test] + list(step[1:]))
+
+
+if __name__ == '__main__':
+    # Run the tests without using Nose.
+    setup()
+    for step in test_steps:
+        if callable(step):
+            step()
+        else:
+            print(step[0])  # description
+            run_test(*step[1:])
+    response = input("Do you want to delete the temporary directory (default: yes)? ")
+    if response not in ["n", "N", "no", "No"]:
+        teardown()
+    else:
+        print("Temporary directory %s not removed" % utils.temporary_dir)


### PR DESCRIPTION
I would like to use Sumatra with MySQL backend (the reason why I can't use PostGres is that central IT where I work only want to have MySQL databases on their servers). I added a patch that allows you use MySQL as backend. By testing it locally it seems to work. Would this be an interesting add-on for the sumatra project?

I am happy to write more rigorous tests, but in that case: Should it be a separate file that is basically copy of `tests/system/test_postgres.py`?