### PR TITLE
Replace deprecated time.clock() with time.process_time()

### DIFF
--- a/sumatra/tee.py
+++ b/sumatra/tee.py
@@ -5,7 +5,11 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 from builtins import str
-import logging, sys, signal, subprocess, types, time, os, codecs, platform
+import logging, sys, signal, subprocess, types, os, codecs, platform
+try:
+    from time import process_time
+except ImportError:  # Python 2.7 fallback
+    from time import clock as process_time
 
 string_types = str,
 
@@ -70,7 +74,7 @@ def system2(cmd, cwd=None, logger=_sentinel, stdout=_sentinel, log_command=_sent
         This method return (returncode, output_lines_as_list)
 
         """
-        t = time.clock()
+        t = process_time()
         output = []
         if log_command is _sentinel: log_command = globals().get('log_command')
         if timing is _sentinel: timing = globals().get('timing')
@@ -155,7 +159,7 @@ def system2(cmd, cwd=None, logger=_sentinel, stdout=_sentinel, log_command=_sent
                             sys.stdout.flush()
             returncode = p.wait()
         except KeyboardInterrupt:
-            # Popen.returncode: 
+            # Popen.returncode:
             #   "A negative value -N indicates that the child was terminated by signal N (Unix only)."
             # see https://docs.python.org/2/library/subprocess.html#subprocess.Popen.returncode
             returncode = -signal.SIGINT
@@ -164,7 +168,7 @@ def system2(cmd, cwd=None, logger=_sentinel, stdout=_sentinel, log_command=_sent
                         def secondsToStr(t):
                                 from functools import reduce
                                 return "%02d:%02d:%02d" % reduce(lambda ll,b : divmod(ll[0],b) + ll[1:], [(t*1000,),1000,60,60])[:3]
-                        mylogger("Returned: %d (execution time %s)\n" % (returncode, secondsToStr(time.clock()-t)))
+                        mylogger("Returned: %d (execution time %s)\n" % (returncode, secondsToStr(process_time()-t)))
                 else:
                         mylogger("Returned: %d\n" % (returncode))
 


### PR DESCRIPTION
Sumatra is still using `time.clock()`, which has been deprecated since Python 3.3 and is no longer available on Python 3.8:

  > The function time.clock() has been removed, after having been deprecated since Python 3.3: use time.perf_counter() or time.process_time() instead, depending on your requirements, to have well-defined behavior. (Contributed by Matthias Bussonnier in bpo-36895.) \
([Python 3.8 - What's new ?](https://docs.python.org/3/whatsnew/3.8.html#api-and-feature-removals)).

Accordingly, running `nosetests test/unittests/test_launch.py` on Python 3.8 raises the following exception:

    ======================================================================
    ERROR: test__run__should_accept_None_for_the_parameter_file (unittests.test_launch.TestSerialLaunchMode)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/home/alex/usr/local/python/sumatra/test/unittests/test_launch.py", line 65, in test__run__should_accept_None_for_the_parameter_file
        self.lm.run(prog, "valid_test_script.py", None)
      File "/home/alex/usr/local/python/sumatra/sumatra/launch.py", line 111, in run
        result, output = tee.system2(cmd, cwd=self.working_directory, stdout=True, catch_stderr=catch_stderr)  # cwd only relevant for local launch, not for MPI, for example
      File "/home/alex/usr/local/python/sumatra/sumatra/tee.py", line 73, in system2
        t = time.clock()
    AttributeError: module 'time' has no attribute 'clock'

This PR replaces `time.clock()` with `time.process_time()` (this seemed a better option than `perf_counter()`, although I have no strong opinions on this choice).
