### PR TITLE
Fix: Replace literal tests by equal tests.

### DIFF
--- a/sumatra/projects.py
+++ b/sumatra/projects.py
@@ -359,7 +359,7 @@ class Project(object):
             record = self.record_store.get(self.name, label)
         except Exception as e:
             raise Exception("%s. label=<%s>" % (e, label))
-        if replace or record.outcome is "":
+        if replace or record.outcome == "":
             record.outcome = comment
         else:
             record.outcome = record.outcome + "\n" + comment

--- a/sumatra/versioncontrol/_git.py
+++ b/sumatra/versioncontrol/_git.py
@@ -84,7 +84,7 @@ class GitWorkingCopy(WorkingCopy):
 
     def use_version(self, version):
         logger.debug("Using git version: %s" % version)
-        if version is not 'master':
+        if version != 'master':
             assert not self.has_changed()
         g = git.Git(self.path)
         g.checkout(version)


### PR DESCRIPTION
This removes Python warnings: in two locations the code used

    is ""

instead of

    == ""