### PR TITLE
Prevent error from unconfigured django.

### DIFF
--- a/sumatra/recordstore/django_store/models.py
+++ b/sumatra/recordstore/django_store/models.py
@@ -18,6 +18,10 @@ import django
 from distutils.version import LooseVersion
 from sumatra.core import get_registered_components
 import warnings
+# Hack to prevent `import tagging.fields` from failing
+import django.conf
+if django.conf.settings._wrapped is django.conf.empty:
+    django.conf.settings.configure()
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     import tagging.fields


### PR DESCRIPTION
Initializes settings configuration if needed.

It’s a bit of a hacky solution because it checks the private variable  `django.conf.settings._wrapped`, but if Django is being phased out anyway, maybe this is fine.