### PR TITLE
Fix: Fix logic in `project.save()` for Python 3.11+

### DIFF
--- a/sumatra/projects.py
+++ b/sumatra/projects.py
@@ -147,10 +147,14 @@ class Project(object):
                 else:
                     # Default value for unrecognised parameters
                     attr = None
-            if hasattr(attr, "__getstate__"):
-                state[name] = {'type': attr.__class__.__module__ + "." + attr.__class__.__name__}
-                for key, value in attr.__getstate__().items():
-                    state[name][key] = value
+            if hasattr(attr, "__getstate__"):  # For Python 3.11+, all objects have __getstate__. Default return value is None.
+                attr_state = attr.__getstate__()
+                if attr_state is None:
+                    state[name] = attr
+                else:
+                    state[name] = {'type': attr.__class__.__module__ + "." + attr.__class__.__name__}
+                    for key, value in attr.__getstate__().items():
+                        state[name][key] = value
             else:
                 state[name] = attr
         f = open(_get_project_file(self.path), 'w')  # should check if file exists?


### PR DESCRIPTION
Now all objects define `__getstate__` (with default value `None`)

Previous logic in `project.save()` would test for existence of that method, and if present, use it to populate a state variable.
This no longer works, because a `None` value passes the first test (it exists) but it is obviously not callable.
This small patch adds support for Python 3.11+ by also checking that `__getstate__` is not `None` before attempting to call it.