### PR TITLE
Use `with` everywhere to open files

### DIFF
--- a/doc/build_reference.py
+++ b/doc/build_reference.py
@@ -24,16 +24,15 @@ for mode in modes:
 
 sys.stdout = sys.__stdout__
 
-f = open("command_reference.txt", "w")
-f.write("=====================\n")
-f.write("smt command reference\n")
-f.write("=====================\n\n")
+with open("command_reference.txt", "w") as f:
+    f.write("=====================\n")
+    f.write("smt command reference\n")
+    f.write("=====================\n\n")
 
-for mode in modes:
-    sio = usage[mode]
-    f.write(mode + '\n')
-    f.write('-'*len(mode) + '\n::\n\n    ')
-    sio.seek(0)
-    f.write("    ".join(sio.readlines()) + '\n')
-    sio.close()
-f.close()
+    for mode in modes:
+        sio = usage[mode]
+        f.write(mode + '\n')
+        f.write('-'*len(mode) + '\n::\n\n    ')
+        sio.seek(0)
+        f.write("    ".join(sio.readlines()) + '\n')
+        sio.close()

--- a/sumatra/commands.py
+++ b/sumatra/commands.py
@@ -538,9 +538,8 @@ def comment(argv):
     args = parser.parse_args(argv)
 
     if args.file:
-        f = open(args.comment, 'r')
-        comment = f.read()
-        f.close()
+        with open(args.comment, 'r') as f:
+            comment = f.read()
     else:
         comment = args.comment
 
@@ -686,9 +685,8 @@ def upgrade(argv):
     project.record_store.clear()
     filename = "%s/records_export.json" % backup_dir
     if os.path.exists(filename):
-        f = open(filename)
-        project.record_store.import_(project.name, f.read())
-        f.close()
+        with open(filename) as f:
+            project.record_store.import_(project.name, f.read())
     else:
         print("Record file not found")
         sys.exit(1)

--- a/sumatra/datastore/filesystem.py
+++ b/sumatra/datastore/filesystem.py
@@ -36,12 +36,11 @@ class DataFile(DataItem):
         self.mimetype, self.encoding = mimetypes.guess_type(self.full_path)
 
     def get_content(self, max_length=None):
-        f = open(self.full_path, 'rb')
-        if max_length:
-            content = f.read(max_length)
-        else:
-            content = f.read()
-        f.close()
+        with open(self.full_path, 'rb') as f:
+            if max_length:
+                content = f.read(max_length)
+            else:
+                content = f.read()
         return content
     content = property(fget=get_content)
 
@@ -52,9 +51,8 @@ class DataFile(DataItem):
             cmd = "sort %s > %s" % (self.full_path, sorted_path)
             job = Popen(cmd, shell=True)
             job.wait()
-        f = open(sorted_path, 'rb')
-        content = f.read()
-        f.close()
+        with open(sorted_path, 'rb') as f:
+            content = f.read()
         if len(content) != self.size:  # sort adds a \n if the file does not end with one
             assert len(content) == self.size + 1
             content = content[:-1]

--- a/sumatra/dependency_finder/matlab.py
+++ b/sumatra/dependency_finder/matlab.py
@@ -36,15 +36,15 @@ def save_dependencies(cmd, filename):
 
 def find_dependencies(filename, executable):
     #ifile = os.path.join(os.getcwd(), 'depfun.data')
-    file_data = (open('depfun.data', 'r'))
-    content = file_data.read()
-    paths = re.split('1: ', content)[2:]
-    list_deps = []
-    for path in paths:
-        if os.name == 'posix':
-            list_data = path.split('/')
-        else:
-            list_data = path.split('\\')
-        list_deps.append(Dependency(list_data[-2], path.split('\n')[0]))
-    file_data.close() # TODO: find version of external toolboxes
+    with open('depfun.data', 'r') as file_data:
+        content = file_data.read()
+        paths = re.split('1: ', content)[2:]
+        list_deps = []
+        for path in paths:
+            if os.name == 'posix':
+                list_data = path.split('/')
+            else:
+                list_data = path.split('\\')
+            list_deps.append(Dependency(list_data[-2], path.split('\n')[0]))
+    # TODO: find version of external toolboxes
     return list_deps

--- a/sumatra/projects.py
+++ b/sumatra/projects.py
@@ -153,9 +153,8 @@ class Project(object):
                     state[name][key] = value
             else:
                 state[name] = attr
-        f = open(_get_project_file(self.path), 'w')  # should check if file exists?
-        json.dump(state, f, indent=2)
-        f.close()
+        with open(_get_project_file(self.path), 'w') as f:  # should check if file exists?
+            json.dump(state, f, indent=2)
 
     def info(self):
         """Show some basic information about the project."""
@@ -389,9 +388,8 @@ class Project(object):
         # copy the project data
         shutil.copy(".smt/project", ".smt/project_export.json")
         # export the record data
-        f = open(".smt/records_export.json", 'w')
-        f.write(self.record_store.export(self.name))
-        f.close()
+        with open(".smt/records_export.json", 'w') as f:
+            f.write(self.record_store.export(self.name))
 
     def repeat(self, original_label, new_label=None):
         if original_label == 'last':
@@ -470,9 +468,8 @@ class Project(object):
 
 
 def _load_project_from_json(path):
-    f = open(_get_project_file(path), 'r')
-    data = json.load(f)
-    f.close()
+    with open(_get_project_file(path), 'r') as f:
+        data = json.load(f)
     prj = Project.__new__(Project)
     prj.path = path
     for key, value in data.items():
@@ -498,9 +495,8 @@ def _load_project_from_json(path):
 
 def _load_project_from_pickle(path):
     # earlier versions of Sumatra saved Projects using pickle
-    f = open(_get_project_file(path), 'r')
-    prj = pickle.load(f)
-    f.close()
+    with open(_get_project_file(path), 'r') as f:
+        prj = pickle.load(f)
     return prj
 
 

--- a/tools/export.py
+++ b/tools/export.py
@@ -102,18 +102,17 @@ def export_records(output_file):
     store = load_recordstore()
     if minor_version < 3:
         patch_sumatra()
-    f = open(output_file, 'w')
-    if minor_version == 1:
-        json.dump([encode_record(record) for record in store.list(groups=None)],
-                  f, indent=2)
-    else:
-        project_name = projects.load_project().name
-        if minor_version == 2:
-            json.dump([encode_record(record) for record in store.list(project_name)],
+    with open(output_file, 'w') as f:
+        if minor_version == 1:
+            json.dump([encode_record(record) for record in store.list(groups=None)],
                       f, indent=2)
         else:
-            f.write(store.export(project_name))
-    f.close()
+            project_name = projects.load_project().name
+            if minor_version == 2:
+                json.dump([encode_record(record) for record in store.list(project_name)],
+                          f, indent=2)
+            else:
+                f.write(store.export(project_name))
 
 
 def patch_sumatra():
@@ -172,9 +171,8 @@ def export_project(output_file):
         state['record_store']['db_file'] = ".smt/records" #prj.record_store._db_file
     else:
         state['record_store']['shelf_name'] = ".smt/records" #prj.record_store._shelf_name
-    f = open(output_file, 'w')
-    json.dump(state, f, indent=2)
-    f.close()
+    with open(output_file, 'w') as f:
+        json.dump(state, f, indent=2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As far as I know, there is no advantage to using `f = open() ... f.close() when a `with open() as f:` will do. The `with` form deals better with corner cases where program execution ends unexpectedly, and is generally more Pythonic.