### PR TITLE
[VC] Allow launching from any directory (git only)

### DIFF
--- a/sumatra/versioncontrol/_git.py
+++ b/sumatra/versioncontrol/_git.py
@@ -200,6 +200,7 @@ class GitRepository(Repository):
         self.__repository = git.Repo(path)
 
     def get_working_copy(self, path=None):
+        path = self.url if path is None else path
         return GitWorkingCopy(path)
 
     def _get_upstream(self):


### PR DESCRIPTION
`GitRepository.get_working_copy` now looks for the repository's url by default, rather than the current working directory.
Other VC systems are left unchanged at the moment.