### PR TITLE
Enh: Make django optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ class sdist_git(sdist):
         return repo.head.commit.hexsha[:7]
 
 
-install_requires = ['Django>=1.8, <2', 'django-tagging', 'httplib2',
+install_requires = ['httplib2',
                     'docutils', 'jinja2', 'parameters', 'future']
 major_python_version, minor_python_version, _, _, _ = sys.version_info
 if major_python_version < 3 or (major_python_version == 3 and minor_python_version < 4):
@@ -75,5 +75,7 @@ setup(
                       'hg': 'hgapi',
                       'git': 'GitPython',
                       'bzr': 'bzr',
-                      'mpi': 'mpi4py'}
+                      'mpi': 'mpi4py',
+                      'django': ['Django>=1.8, <2', 'django-tagging']
+                      }
 )

--- a/sumatra/projects.py
+++ b/sumatra/projects.py
@@ -35,7 +35,7 @@ from copy import deepcopy
 import uuid
 import sumatra
 try:
-    import django
+    import django.db.utils
 except ImportError:
     class DjangoDatabaseError:  # If django can't be loaded, a django..DatabaseError also
         pass                    # cannot be raised, so a mock exception class is all we need

--- a/sumatra/projects.py
+++ b/sumatra/projects.py
@@ -34,7 +34,13 @@ import pickle
 from copy import deepcopy
 import uuid
 import sumatra
-import django
+try:
+    import django
+except ImportError:
+    class DjangoDatabaseError:  # If django can't be loaded, a django..DatabaseError also
+        pass                    # cannot be raised, so a mock exception class is all we need
+else:
+    DjangoDatabaseError = django.db.utils.DatabaseError
 import sqlite3
 import time
 import shutil
@@ -270,7 +276,7 @@ class Project(object):
                 success = True
                 self._most_recent = record.label
                 logger.debug("Created record: %s" % self.most_recent())
-            except (django.db.utils.DatabaseError, sqlite3.OperationalError):
+            except (DjangoDatabaseError, sqlite3.OperationalError):
                 print("Failed to save record due to database error. Trying again in {0} seconds. (Attempt {1}/{2})".format(sleep_seconds, cnt, max_tries))
                 time.sleep(sleep_seconds)
                 cnt += 1


### PR DESCRIPTION
The outdated Django causes a bunch of headaches when trying to install Sumatra into a project, since it creates dependency conflicts with any other library that uses Django. This happens for example when I install _bokeh_ in the same project.
At present my solution is to not use the Django record store at all, and just rely on the ShelveRecordStore. It’s not as performant, doesn’t support concurrency, but comparatively it’s still more reliable.
However, Sumatra still lists Django as a hard dependency, and some of the core modules can’t be imported without it, even though with a different record store the Django dependency is never actually used.

This patch removes Django from the required dependencies, and creates a new extra dependency so it can be installed with `pip install sumatra[django]`.
It also adds an import guard in _sumatra/projects.py_ so that module can be imported without errors when Django is not installed.