### PR TITLE
Enh: Make RecordDifference more robust

### DIFF
--- a/sumatra/records.py
+++ b/sumatra/records.py
@@ -301,7 +301,8 @@ class RecordDifference(object):
         self.main_file_differs = recordA.main_file != recordB.main_file
         self.version_differs = recordA.version != recordB.version
         for rec in recordA, recordB:
-            if rec.parameters:
+            # hasattr guard is for some malformed custom parameter type
+            if rec.parameters and hasattr(rec.parameters, 'pop'):
                 rec.parameters.pop("sumatra_label", 1)
         self.parameters_differ = recordA.parameters != recordB.parameters
         self.script_arguments_differ = recordA.script_arguments != recordB.script_arguments


### PR DESCRIPTION
This fixes a corner case in `records.py::RecordDifference`.

In cases where record parameters are malformed, they may not load correctly as a dict, and then `rec.parameters.pop` raises `AttributeError`. One may still want to compare the record to another however – for example, to identify differences with a record where parameters are not malformed. Adding a `hasattr` guard helps with this corner case, and as far as I can tell has no downsides.