### PR TITLE
WIP: More Windows-compatible

### DIFF
--- a/sumatra/core.py
+++ b/sumatra/core.py
@@ -51,7 +51,7 @@ def get_encoding():
     return encoding
 
 
-def run(args, cwd=None, shell=False, kill_tree=True, timeout=-1, env=None):
+def run(args, cwd=None, shell=False, kill_tree=True, timeout=None, env=None):
     """
     Run a command with a timeout.
     """
@@ -65,9 +65,8 @@ def run(args, cwd=None, shell=False, kill_tree=True, timeout=-1, env=None):
 
 
 def _get_process_children(pid):
-    p = subprocess.Popen('ps --no-headers -o pid --ppid %d' % pid, shell=True,
-                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    stdout, stderr = p.communicate()
+    completed_command = subprocess.run(['ps','--no-headers', '-o', 'pid', '--ppid', pid], shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout = completed_command.stdout
     return [int(child_pid) for child_pid in stdout.split()]
 
 

--- a/sumatra/dependency_finder/matlab.py
+++ b/sumatra/dependency_finder/matlab.py
@@ -21,18 +21,6 @@ class Dependency(core.BaseDependency):
         super(Dependency, self).__init__(module_name, path, version, diff, source)
 
 
-def save_dependencies(cmd, filename):
-    ''' save all dependencies to the file in the current folder '''
-    file_dep = "depfun %s -toponly -quiet -print depfun.data;" %filename # save dependencies to a file
-    mat_args = cmd.split('-r ')[-1]
-    cmd = "%s; %s quit" %(mat_args, file_dep)
-    p = subprocess.Popen(['matlab','-nodesktop', '-nosplash', '-nojvm', ' -nodisplay', '-wait', '-r', cmd], stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)    
-    result = p.wait()
-    output = p.stdout.read() 
-    # import pdb; pdb.set_trace() 
-    return result, output
-
-
 def find_dependencies(filename, executable):
     #ifile = os.path.join(os.getcwd(), 'depfun.data')
     with open('depfun.data', 'r') as file_data:

--- a/sumatra/programs.py
+++ b/sumatra/programs.py
@@ -100,6 +100,9 @@ class Executable(object):
                 print('Multiple versions found, using %s. If you wish to use a different version, please specify it explicitly' % executable)
         return executable
 
+    def generate_command(self, main_file, arguments):
+        return [self.path, main_file, arguments]
+
     def _get_version(self):
         returncode, output, err = run([self.path, "--version"],
                                       shell=False, timeout=5)
@@ -173,6 +176,8 @@ class MatlabExecutable(Executable):
             command_line_output=output + err,
             pattern=version_pattern_matlab
         )
+    def generate_command(self, main_file, arguments):
+        return [self.path, '-batch', main_file.replace('.m','')]
 
 
 @component


### PR DESCRIPTION
The main thing in the way of Windows compatibility is using `shell=True`, which seems to be recommended against for security reasons anyway.

A few things are not yet fixed:

* [ ] Archiving acts weird, I *think* it expects slash-separated file names inside tar files but receives backslashes
* [x] Matlab doesn't yet work, it still gets called with `--version` for some reason
* [ ] Probably a bunch of things I haven't tested yet

Anyway, figured I would offer up what I've found so far. Is this too agressive?